### PR TITLE
log instead of error if multiple records with same hash found

### DIFF
--- a/client/indexd.go
+++ b/client/indexd.go
@@ -560,15 +560,18 @@ func (cl *IndexDClient) GetObjectByHash(hashType string, hash string) (*drs.DRSO
 		return nil, fmt.Errorf("error unmarshaling (%s:%s): %v", hashType, hash, err)
 	}
 
-	// if one record found, return it
-	if len(records.Records) > 1 {
-		return nil, fmt.Errorf("expected at most 1 record for OID %s:%s, got %d records", hashType, hash, len(records.Records))
-	}
 	// if no records found, return nil to handle in caller
 	if len(records.Records) == 0 {
 		return nil, nil
 	}
+
+	// if more than one record found, write it to log
+	if len(records.Records) > 1 {
+		myLogger.Log("INFO: found more than 1 record for OID %s:%s, got %d records", hashType, hash, len(records.Records))
+	}
+
 	drsId := records.Records[0].Did
+	myLogger.Log("Using the first matching record (%s): %s", drsId, records.Records[0].FileName)
 
 	drsObj, err := cl.GetObject(drsId)
 


### PR DESCRIPTION
### Context
Initially, `GetObjectByHash` would error if multiple records were found, as git drs would almost never have duplicate indexd records for the same hash, as the indexd GUID is minted from the hash. However, for existing indexd records created by g3t, this is not true, as a indexd GUID is minted using a filepath. As a result, having two copies of the same file in different file paths would result in 2 separate indexd records being created.

This small fix handles this use case of handling g3t-created indexd records within git drs.

### Testing Checklist

- [ ] Able pull boo.txt from  [git-drs-test-repo](https://source.ohsu.edu/CBDS/git-drs-test-repo) successfully.

### Testing Setup

This was already done for you, but leaving pseudocode steps here for completeness
1. `g3t add --sha256 <sha>` and push for two separate files (see [here](https://calypr-dev.ohsu.edu/index/index?hash=sha256:de3946125588216a4cbcf6cc9bc605ac3f8470a9d7a9e73a74e8a5a90c32737d&authz=/programs/cbds/projects/qww) for the two records with the same hash)
2. Create pointer file using sha and size from above
3. Track (`git lfs track boo.txt && git add .gitattributes`) and push file in git-drs-test-repo (`GIT_LFS_SKIP_PUSH=1 git push`). No need to register the file again (ie do an LFS push to gen3) since file was registered via g3t push