### PR TITLE
chore/increase-test-coverage

### DIFF
--- a/client/indexd/auth_handler_test.go
+++ b/client/indexd/auth_handler_test.go
@@ -1,0 +1,69 @@
+package indexd_client
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/calypr/data-client/client/conf"
+	"github.com/golang-jwt/jwt/v5"
+)
+
+func TestGetExpiration(t *testing.T) {
+	claims := jwt.MapClaims{
+		"exp": float64(time.Now().Add(2 * time.Hour).Unix()),
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	tokenString, err := token.SignedString([]byte("secret"))
+	if err != nil {
+		t.Fatalf("sign token: %v", err)
+	}
+
+	exp, err := GetExpiration("bearer " + tokenString)
+	if err != nil {
+		t.Fatalf("GetExpiration error: %v", err)
+	}
+	if exp.Before(time.Now()) {
+		t.Fatalf("expected future expiration, got %v", exp)
+	}
+}
+
+func TestGetExpiration_MissingExp(t *testing.T) {
+	claims := jwt.MapClaims{
+		"sub": "user",
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	tokenString, err := token.SignedString([]byte("secret"))
+	if err != nil {
+		t.Fatalf("sign token: %v", err)
+	}
+
+	if _, err := GetExpiration(tokenString); err == nil {
+		t.Fatalf("expected error for missing exp")
+	}
+}
+
+func TestRealAuthHandler_AddAuthHeader(t *testing.T) {
+	claims := jwt.MapClaims{
+		"exp": float64(time.Now().Add(2 * time.Hour).Unix()),
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	tokenString, err := token.SignedString([]byte("secret"))
+	if err != nil {
+		t.Fatalf("sign token: %v", err)
+	}
+
+	rh := &RealAuthHandler{Cred: conf.Credential{AccessToken: tokenString}}
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://example.com", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+
+	if err := rh.AddAuthHeader(req); err != nil {
+		t.Fatalf("AddAuthHeader error: %v", err)
+	}
+	if req.Header.Get("Authorization") == "" {
+		t.Fatalf("expected Authorization header")
+	}
+}

--- a/client/indexd/convert_test.go
+++ b/client/indexd/convert_test.go
@@ -1,0 +1,57 @@
+package indexd_client
+
+import (
+	"testing"
+
+	"github.com/calypr/git-drs/drs"
+	"github.com/calypr/git-drs/drs/hash"
+)
+
+func TestIndexdRecordConversions(t *testing.T) {
+	accessMethods := []drs.AccessMethod{
+		{
+			AccessURL: drs.AccessURL{URL: "s3://bucket/key"},
+			Authorizations: &drs.Authorizations{
+				Value: "/programs/test/projects/proj",
+			},
+		},
+	}
+	input := &drs.DRSObject{
+		Id:            "did-1",
+		Name:          "file.txt",
+		Size:          123,
+		AccessMethods: accessMethods,
+		Checksums:     hash.HashInfo{SHA256: "sha-256"},
+	}
+
+	indexdRecord, err := indexdRecordFromDrsObject(input)
+	if err != nil {
+		t.Fatalf("indexdRecordFromDrsObject error: %v", err)
+	}
+	if indexdRecord.Did != input.Id || indexdRecord.FileName != input.Name {
+		t.Fatalf("indexd record mismatch: %+v", indexdRecord)
+	}
+	if len(indexdRecord.URLs) != 1 || indexdRecord.URLs[0] != "s3://bucket/key" {
+		t.Fatalf("unexpected URLs: %+v", indexdRecord.URLs)
+	}
+	if len(indexdRecord.Authz) != 1 || indexdRecord.Authz[0] != "/programs/test/projects/proj" {
+		t.Fatalf("unexpected authz: %+v", indexdRecord.Authz)
+	}
+
+	out, err := indexdRecordToDrsObject(indexdRecord)
+	if err != nil {
+		t.Fatalf("indexdRecordToDrsObject error: %v", err)
+	}
+	if out.Id != input.Id || out.Name != input.Name || out.Size != input.Size {
+		t.Fatalf("drs object mismatch: %+v", out)
+	}
+	if len(out.AccessMethods) != 1 || out.AccessMethods[0].AccessURL.URL != "s3://bucket/key" {
+		t.Fatalf("unexpected access methods: %+v", out.AccessMethods)
+	}
+}
+
+func TestDrsAccessMethodsFromIndexdURLs_AuthzRequired(t *testing.T) {
+	if _, err := drsAccessMethodsFromIndexdURLs([]string{"s3://bucket/key"}, nil); err == nil {
+		t.Fatalf("expected authz error")
+	}
+}

--- a/client/indexd/indexd_client_test.go
+++ b/client/indexd/indexd_client_test.go
@@ -1,0 +1,369 @@
+package indexd_client
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/bytedance/sonic"
+	"github.com/bytedance/sonic/encoder"
+	"github.com/calypr/data-client/client/conf"
+	"github.com/calypr/git-drs/drs"
+	"github.com/calypr/git-drs/drs/hash"
+	"github.com/calypr/git-drs/drslog"
+)
+
+type stubAuthHandler struct{}
+
+func (stubAuthHandler) AddAuthHeader(req *http.Request) error {
+	req.Header.Set("Authorization", "Bearer test")
+	return nil
+}
+
+type mockIndexdServer struct {
+	mu                sync.Mutex
+	listProjectPages  int
+	listObjectsPages  int
+	lastUpdatePayload UpdateInputInfo
+}
+
+func (m *mockIndexdServer) handler(t *testing.T) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		path := r.URL.Path
+		switch {
+		case r.Method == http.MethodGet && path == "/index/index":
+			if hashQuery := r.URL.Query().Get("hash"); hashQuery != "" {
+				record := sampleOutputInfo()
+				page := ListRecords{Records: []OutputInfo{record}}
+				w.WriteHeader(http.StatusOK)
+				_ = encoder.NewStreamEncoder(w).Encode(page)
+				return
+			}
+			if r.URL.Query().Get("authz") != "" {
+				m.mu.Lock()
+				page := m.listProjectPages
+				m.listProjectPages++
+				m.mu.Unlock()
+				w.WriteHeader(http.StatusOK)
+				if page == 0 {
+					_ = encoder.NewStreamEncoder(w).Encode(ListRecords{Records: []OutputInfo{sampleOutputInfo()}})
+				} else {
+					_ = encoder.NewStreamEncoder(w).Encode(ListRecords{Records: []OutputInfo{}})
+				}
+				return
+			}
+		case r.Method == http.MethodPost && path == "/index/index":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"did":"did-1"}`))
+			return
+		case r.Method == http.MethodGet && strings.HasPrefix(path, "/ga4gh/drs/v1/objects"):
+			if path == "/ga4gh/drs/v1/objects" {
+				m.mu.Lock()
+				page := m.listObjectsPages
+				m.listObjectsPages++
+				m.mu.Unlock()
+				w.WriteHeader(http.StatusOK)
+				if page == 0 {
+					_ = encoder.NewStreamEncoder(w).Encode(drs.DRSPage{DRSObjects: []drs.DRSObject{sampleDrsObject()}})
+				} else {
+					_ = encoder.NewStreamEncoder(w).Encode(drs.DRSPage{DRSObjects: []drs.DRSObject{}})
+				}
+				return
+			}
+			obj := sampleOutputObject()
+			w.WriteHeader(http.StatusOK)
+			_ = encoder.NewStreamEncoder(w).Encode(obj)
+			return
+		case r.Method == http.MethodGet && strings.HasPrefix(path, "/index/"):
+			record := sampleOutputInfo()
+			record.Rev = "rev-1"
+			w.WriteHeader(http.StatusOK)
+			_ = encoder.NewStreamEncoder(w).Encode(record)
+			return
+		case r.Method == http.MethodPut && strings.HasPrefix(path, "/index/index/"):
+			body, err := ioReadAll(r)
+			if err != nil {
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			payload := UpdateInputInfo{}
+			if err := sonic.ConfigFastest.Unmarshal(body, &payload); err != nil {
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			m.mu.Lock()
+			m.lastUpdatePayload = payload
+			m.mu.Unlock()
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+
+		w.WriteHeader(http.StatusNotFound)
+	}
+}
+
+func ioReadAll(r *http.Request) ([]byte, error) {
+	var buf bytes.Buffer
+	_, err := buf.ReadFrom(r.Body)
+	return buf.Bytes(), err
+}
+
+func sampleOutputInfo() OutputInfo {
+	return OutputInfo{
+		Did:      "did-1",
+		FileName: "file.txt",
+		URLs:     []string{"s3://bucket/key"},
+		Authz:    []string{"/programs/test/projects/proj"},
+		Hashes:   hash.HashInfo{SHA256: "sha-256"},
+		Size:     123,
+	}
+}
+
+func sampleDrsObject() drs.DRSObject {
+	return drs.DRSObject{
+		Id:   "did-1",
+		Name: "file.txt",
+		Size: 123,
+		Checksums: hash.HashInfo{
+			SHA256: "sha-256",
+		},
+	}
+}
+
+func sampleOutputObject() drs.OutputObject {
+	return drs.OutputObject{
+		Id:   "did-1",
+		Name: "file.txt",
+		Size: 123,
+		Checksums: []hash.Checksum{
+			{Checksum: "sha-256", Type: hash.ChecksumTypeSHA256},
+		},
+	}
+}
+
+func newTestClient(server *httptest.Server) *IndexDClient {
+	base, _ := url.Parse(server.URL)
+	return &IndexDClient{
+		Base:        base,
+		ProjectId:   "test-project",
+		BucketName:  "bucket",
+		Logger:      drslog.NewNoOpLogger(),
+		AuthHandler: stubAuthHandler{},
+		HttpClient:  server.Client(),
+		SConfig:     sonic.ConfigFastest,
+	}
+}
+
+func TestIndexdClient_ListAndQuery(t *testing.T) {
+	mock := &mockIndexdServer{}
+	server := httptest.NewServer(mock.handler(t))
+	defer server.Close()
+
+	client := newTestClient(server)
+
+	records, err := client.GetObjectByHash(&hash.Checksum{Type: hash.ChecksumTypeSHA256, Checksum: "sha-256"})
+	if err != nil {
+		t.Fatalf("GetObjectByHash error: %v", err)
+	}
+	if len(records) != 1 || records[0].Id != "did-1" {
+		t.Fatalf("unexpected records: %+v", records)
+	}
+
+	objChan, err := client.ListObjectsByProject("test-project")
+	if err != nil {
+		t.Fatalf("ListObjectsByProject error: %v", err)
+	}
+	var found bool
+	for res := range objChan {
+		if res.Error != nil {
+			t.Fatalf("ListObjectsByProject result error: %v", res.Error)
+		}
+		if res.Object != nil && res.Object.Id == "did-1" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected object from ListObjectsByProject")
+	}
+
+	listChan, err := client.ListObjects()
+	if err != nil {
+		t.Fatalf("ListObjects error: %v", err)
+	}
+	var listCount int
+	for res := range listChan {
+		if res.Error != nil {
+			t.Fatalf("ListObjects result error: %v", res.Error)
+		}
+		if res.Object != nil {
+			listCount++
+		}
+	}
+	if listCount != 1 {
+		t.Fatalf("expected 1 object from ListObjects, got %d", listCount)
+	}
+
+	sample, err := client.GetProjectSample("test-project", 1)
+	if err != nil {
+		t.Fatalf("GetProjectSample error: %v", err)
+	}
+	if len(sample) != 1 || sample[0].Id != "did-1" {
+		t.Fatalf("unexpected sample: %+v", sample)
+	}
+}
+
+func TestIndexdClient_RegisterAndUpdate(t *testing.T) {
+	mock := &mockIndexdServer{}
+	server := httptest.NewServer(mock.handler(t))
+	defer server.Close()
+
+	client := newTestClient(server)
+
+	indexdObj := &IndexdRecord{
+		Did:      "did-1",
+		FileName: "file.txt",
+		URLs:     []string{"s3://bucket/key"},
+		Authz:    []string{"/programs/test/projects/proj"},
+		Hashes:   hash.HashInfo{SHA256: "sha-256"},
+		Size:     123,
+	}
+
+	obj, err := client.RegisterIndexdRecord(indexdObj)
+	if err != nil {
+		t.Fatalf("RegisterIndexdRecord error: %v", err)
+	}
+	if obj.Id != "did-1" {
+		t.Fatalf("unexpected DRS object: %+v", obj)
+	}
+
+	update := &drs.DRSObject{
+		Name:        "file-updated.txt",
+		Version:     "v2",
+		Description: "updated",
+		AccessMethods: []drs.AccessMethod{
+			{
+				AccessURL:      drs.AccessURL{URL: "s3://bucket/other"},
+				Authorizations: &drs.Authorizations{Value: "/programs/test/projects/proj"},
+			},
+		},
+	}
+
+	updated, err := client.UpdateRecord(update, "did-1")
+	if err != nil {
+		t.Fatalf("UpdateRecord error: %v", err)
+	}
+	if updated.Name != "file.txt" {
+		t.Fatalf("expected updated DRS object from server, got %+v", updated)
+	}
+
+	mock.mu.Lock()
+	payload := mock.lastUpdatePayload
+	mock.mu.Unlock()
+
+	if len(payload.URLs) != 2 {
+		t.Fatalf("expected URLs to include appended entries, got %+v", payload.URLs)
+	}
+	if payload.FileName != "file-updated.txt" || payload.Version != "v2" {
+		t.Fatalf("unexpected payload: %+v", payload)
+	}
+	if payload.Metadata == nil || payload.Metadata["description"] != "updated" {
+		t.Fatalf("expected description metadata, got %+v", payload.Metadata)
+	}
+}
+
+func TestIndexdClient_BuildDrsObj(t *testing.T) {
+	client := &IndexDClient{
+		ProjectId:  "test-project",
+		BucketName: "bucket",
+	}
+
+	obj, err := client.BuildDrsObj("file.txt", "sha-256", 12, "did-1")
+	if err != nil {
+		t.Fatalf("BuildDrsObj error: %v", err)
+	}
+	if obj.Id != "did-1" || obj.Checksums.SHA256 != "sha-256" {
+		t.Fatalf("unexpected drs object: %+v", obj)
+	}
+	if len(obj.AccessMethods) != 1 || !strings.Contains(obj.AccessMethods[0].AccessURL.URL, filepath.Join("bucket", "did-1", "sha-256")) {
+		t.Fatalf("unexpected access URL: %+v", obj.AccessMethods)
+	}
+}
+
+func TestIndexdClient_GetProfile(t *testing.T) {
+	client := &IndexDClient{AuthHandler: &RealAuthHandler{Cred: confCredential("profile")}}
+	profile, err := client.GetProfile()
+	if err != nil {
+		t.Fatalf("GetProfile error: %v", err)
+	}
+	if profile != "profile" {
+		t.Fatalf("expected profile, got %s", profile)
+	}
+}
+
+func confCredential(profile string) conf.Credential {
+	return conf.Credential{Profile: profile}
+}
+
+func TestIndexdClient_GetProfile_Error(t *testing.T) {
+	client := &IndexDClient{AuthHandler: stubAuthHandler{}}
+	if _, err := client.GetProfile(); err == nil {
+		t.Fatalf("expected error for non-real auth handler")
+	}
+}
+
+func TestIndexdClient_GetIndexdRecordByDID(t *testing.T) {
+	mock := &mockIndexdServer{}
+	server := httptest.NewServer(mock.handler(t))
+	defer server.Close()
+
+	client := newTestClient(server)
+
+	record, err := client.GetIndexdRecordByDID("did-1")
+	if err != nil {
+		t.Fatalf("GetIndexdRecordByDID error: %v", err)
+	}
+	if record.Did != "did-1" || record.Rev != "rev-1" {
+		t.Fatalf("unexpected record: %+v", record)
+	}
+}
+
+func TestIndexdClient_GetProjectSample_DefaultLimit(t *testing.T) {
+	mock := &mockIndexdServer{}
+	server := httptest.NewServer(mock.handler(t))
+	defer server.Close()
+
+	client := newTestClient(server)
+
+	sample, err := client.GetProjectSample("test-project", 0)
+	if err != nil {
+		t.Fatalf("GetProjectSample error: %v", err)
+	}
+	if len(sample) != 1 {
+		t.Fatalf("expected default limit sample, got %d", len(sample))
+	}
+}
+
+func TestIndexdClient_NewIndexDClient(t *testing.T) {
+	cred := conf.Credential{APIEndpoint: "https://example.com"}
+	remote := Gen3Remote{ProjectID: "project", Bucket: "bucket"}
+	client, err := NewIndexDClient(cred, remote, drslog.NewNoOpLogger())
+	if err != nil {
+		t.Fatalf("NewIndexDClient error: %v", err)
+	}
+	indexd, ok := client.(*IndexDClient)
+	if !ok {
+		t.Fatalf("expected IndexDClient")
+	}
+	if indexd.ProjectId != "project" || indexd.BucketName != "bucket" {
+		t.Fatalf("unexpected client: %+v", indexd)
+	}
+	if indexd.HttpClient.Timeout != 30*time.Second {
+		t.Fatalf("unexpected http timeout: %v", indexd.HttpClient.Timeout)
+	}
+}

--- a/client/indexd/tests/README.md
+++ b/client/indexd/tests/README.md
@@ -1,0 +1,47 @@
+
+# Tests for `client/indexd/tests`
+
+Overview
+- This directory contains unit and integration tests related to the indexd client.
+- Tests may exercise network services (indexd, Postgres, GitHub) and can be destructive for remote resources. Run in an isolated/test environment.
+
+Location
+- `client/indexd/tests`
+
+Prerequisites
+- macOS development environment.
+- Go toolchain (Go modules enabled). Recommended: Go 1.20+.
+- Ensure required binaries are on `PATH` if tests call external tools (for example: `git`, `git-lfs`, `docker`).
+- Run `go mod download` from the repository root before running tests.
+
+Common environment variables
+- `GH_PAT` — GitHub token (used by tests that create/delete repos).
+- `GIT_DRS_REMOTE` — profile/remote name used by git-drs tests.
+- `INDEXD_URL` / `INDEXD_TOKEN` — endpoint and token if tests interact with an indexd service.
+- `POSTGRES_HOST`, `POSTGRES_PASSWORD` — if tests need a Postgres instance.
+Note: Not all variables are required for every test. Check individual test code for exact requirements.
+
+Running tests
+- From repository root:
+  - `go test ./client/indexd/tests -v`
+- From the tests directory:
+  - `cd client/indexd/tests && go test -v`
+- Run a single test (by name or regex):
+  - `go test -v -run TestName`
+- Force rebuild / avoid caching:
+  - `go test -v -run TestName -count=1`
+- Run with race detector:
+  - `go test -race -v`
+- Increase test timeout:
+  - `go test -v -timeout 5m`
+
+Notes & troubleshooting
+- If tests fail due to missing services, start required services (indexd, Postgres, etc.) or mock them as appropriate.
+- If tests modify remote resources (GitHub repos, buckets), provide credentials pointing to a disposable/test account/org.
+- Inspect test logs (`-v`) for external command output.
+- If a test depends on `git-lfs`, ensure `git lfs install --skip-smudge` has been run in the environment or CI image.
+
+CI / Safety
+- Run integration tests in controlled CI or a dedicated test environment.
+- Use separate credentials and test orgs to avoid impacting production data.
+

--- a/client/indexd/utils_test.go
+++ b/client/indexd/utils_test.go
@@ -1,0 +1,67 @@
+package indexd_client
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/bytedance/sonic/encoder"
+	"github.com/calypr/git-drs/s3_utils"
+)
+
+type testAuthHandler struct {
+	token string
+}
+
+func (t testAuthHandler) AddAuthHeader(req *http.Request) error {
+	if t.token != "" {
+		req.Header.Set("Authorization", "Bearer "+t.token)
+	}
+	return nil
+}
+
+func TestGetBucketDetailsWithAuth(t *testing.T) {
+	var authHeader string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		authHeader = r.Header.Get("Authorization")
+		resp := s3_utils.S3BucketsResponse{
+			S3Buckets: map[string]*s3_utils.S3Bucket{
+				"bucket": {Region: "us-east-1", EndpointURL: "https://s3.example.com"},
+			},
+		}
+		w.WriteHeader(http.StatusOK)
+		_ = encoder.NewStreamEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	bucket, err := GetBucketDetailsWithAuth(context.Background(), "bucket", server.URL, testAuthHandler{token: "token"}, server.Client())
+	if err != nil {
+		t.Fatalf("GetBucketDetailsWithAuth error: %v", err)
+	}
+	if authHeader != "Bearer token" {
+		t.Fatalf("expected auth header set, got %q", authHeader)
+	}
+	if bucket.Region != "us-east-1" || bucket.EndpointURL != "https://s3.example.com" {
+		t.Fatalf("unexpected bucket details: %+v", bucket)
+	}
+}
+
+func TestGetBucketDetailsWithAuth_NotFound(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := s3_utils.S3BucketsResponse{
+			S3Buckets: map[string]*s3_utils.S3Bucket{},
+		}
+		w.WriteHeader(http.StatusOK)
+		_ = encoder.NewStreamEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	bucket, err := GetBucketDetailsWithAuth(context.Background(), "missing", server.URL, nil, server.Client())
+	if err != nil {
+		t.Fatalf("GetBucketDetailsWithAuth error: %v", err)
+	}
+	if bucket != nil {
+		t.Fatalf("expected nil bucket, got %+v", bucket)
+	}
+}

--- a/cmd/addurl/main_test.go
+++ b/cmd/addurl/main_test.go
@@ -1,0 +1,28 @@
+package addurl
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/calypr/git-drs/internal/testutils"
+)
+
+func TestGeneratePointerFile(t *testing.T) {
+	testutils.SetupTestGitRepo(t)
+
+	path := filepath.Join("data", "file.txt")
+	err := generatePointerFile(path, "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", 10)
+	if err != nil {
+		t.Fatalf("generatePointerFile error: %v", err)
+	}
+
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read pointer file: %v", err)
+	}
+
+	if len(content) == 0 {
+		t.Fatalf("expected pointer file content")
+	}
+}

--- a/cmd/initialize/main_test.go
+++ b/cmd/initialize/main_test.go
@@ -1,0 +1,61 @@
+package initialize
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/calypr/git-drs/drslog"
+	"github.com/calypr/git-drs/internal/testutils"
+)
+
+func TestEnsureDrsObjectsIgnore(t *testing.T) {
+	testutils.SetupTestGitRepo(t)
+	logger := drslog.NewNoOpLogger()
+
+	if err := ensureDrsObjectsIgnore(".drs/objects", logger); err != nil {
+		t.Fatalf("ensureDrsObjectsIgnore error: %v", err)
+	}
+	content, err := os.ReadFile(".gitignore")
+	if err != nil {
+		t.Fatalf("read .gitignore: %v", err)
+	}
+	if !strings.Contains(string(content), ".drs/objects") {
+		t.Fatalf("expected ignore pattern in .gitignore")
+	}
+
+	if err := ensureDrsObjectsIgnore(".drs/objects", logger); err != nil {
+		t.Fatalf("ensureDrsObjectsIgnore second call error: %v", err)
+	}
+}
+
+func TestInstallPrePushHook(t *testing.T) {
+	testutils.SetupTestGitRepo(t)
+	logger := drslog.NewNoOpLogger()
+
+	if err := installPrePushHook(logger); err != nil {
+		t.Fatalf("installPrePushHook error: %v", err)
+	}
+
+	hookPath := filepath.Join(".git", "hooks", "pre-push")
+	content, err := os.ReadFile(hookPath)
+	if err != nil {
+		t.Fatalf("read hook: %v", err)
+	}
+	if !strings.Contains(string(content), "git drs prepush") {
+		t.Fatalf("expected hook to contain git drs prepush")
+	}
+
+	if err := installPrePushHook(logger); err != nil {
+		t.Fatalf("installPrePushHook second call error: %v", err)
+	}
+}
+
+func TestInitGitConfig(t *testing.T) {
+	testutils.SetupTestGitRepo(t)
+	transfers = 2
+	if err := initGitConfig(); err != nil {
+		t.Fatalf("initGitConfig error: %v", err)
+	}
+}

--- a/cmd/list/main_test.go
+++ b/cmd/list/main_test.go
@@ -1,0 +1,25 @@
+package list
+
+import (
+	"testing"
+
+	"github.com/calypr/git-drs/drs"
+	"github.com/calypr/git-drs/drs/hash"
+)
+
+func TestGetChecksumPos(t *testing.T) {
+	if pos := getChecksumPos(hash.ChecksumTypeSHA256, checksumPref); pos != 0 {
+		t.Fatalf("expected SHA256 at pos 0, got %d", pos)
+	}
+	if pos := getChecksumPos(hash.ChecksumType("missing"), checksumPref); pos != -1 {
+		t.Fatalf("expected missing checksum -1, got %d", pos)
+	}
+}
+
+func TestGetCheckSumStr(t *testing.T) {
+	obj := drs.DRSObject{Checksums: hash.HashInfo{MD5: "md5", SHA256: "sha"}}
+	value := getCheckSumStr(obj)
+	if value != "sha256:sha" {
+		t.Fatalf("unexpected checksum string: %s", value)
+	}
+}

--- a/cmd/transfer/worker_test.go
+++ b/cmd/transfer/worker_test.go
@@ -1,0 +1,145 @@
+package transfer
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/bytedance/sonic"
+	"github.com/calypr/git-drs/drs"
+	"github.com/calypr/git-drs/drs/hash"
+	"github.com/calypr/git-drs/lfs"
+	"github.com/calypr/git-drs/s3_utils"
+)
+
+type mockClient struct {
+	downloadURL string
+	registerObj *drs.DRSObject
+}
+
+func (m mockClient) GetProjectId() string                           { return "project" }
+func (m mockClient) GetObject(id string) (*drs.DRSObject, error)    { return nil, nil }
+func (m mockClient) ListObjects() (chan drs.DRSObjectResult, error) { return nil, nil }
+func (m mockClient) ListObjectsByProject(project string) (chan drs.DRSObjectResult, error) {
+	return nil, nil
+}
+func (m mockClient) GetDownloadURL(oid string) (*drs.AccessURL, error) {
+	return &drs.AccessURL{URL: m.downloadURL}, nil
+}
+func (m mockClient) GetObjectByHash(sum *hash.Checksum) ([]drs.DRSObject, error) { return nil, nil }
+func (m mockClient) DeleteRecordsByProject(project string) error                 { return nil }
+func (m mockClient) DeleteRecord(oid string) error                               { return nil }
+func (m mockClient) RegisterRecord(indexdObject *drs.DRSObject) (*drs.DRSObject, error) {
+	return nil, nil
+}
+func (m mockClient) RegisterFile(oid string) (*drs.DRSObject, error) { return m.registerObj, nil }
+func (m mockClient) UpdateRecord(updateInfo *drs.DRSObject, did string) (*drs.DRSObject, error) {
+	return nil, nil
+}
+func (m mockClient) BuildDrsObj(fileName string, checksum string, size int64, drsId string) (*drs.DRSObject, error) {
+	return nil, nil
+}
+func (m mockClient) AddURL(s3URL, sha256, awsAccessKey, awsSecretKey, regionFlag, endpointFlag string, opts ...s3_utils.AddURLOption) (s3_utils.S3Meta, error) {
+	return s3_utils.S3Meta{}, nil
+}
+
+func TestDownloadWorker(t *testing.T) {
+	tmp := t.TempDir()
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(tmp); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(cwd)
+	})
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("content"))
+	}))
+	defer server.Close()
+
+	oid := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	msg := lfs.DownloadMessage{Event: "download", Oid: oid}
+	payload, err := sonic.ConfigFastest.Marshal(msg)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	jobs := make(chan TransferJob, 1)
+	results := make(chan TransferResult, 1)
+	go downloadWorker(1, jobs, results)
+
+	jobs <- TransferJob{data: payload, drsClient: mockClient{downloadURL: server.URL}}
+	close(jobs)
+
+	res := <-results
+	complete, ok := res.data.(lfs.CompleteMessage)
+	if !ok {
+		t.Fatalf("expected CompleteMessage, got %T", res.data)
+	}
+	if complete.Oid != oid {
+		t.Fatalf("unexpected oid: %s", complete.Oid)
+	}
+	if filepath.Base(complete.Path) != oid {
+		t.Fatalf("unexpected path: %s", complete.Path)
+	}
+}
+
+func TestUploadWorker(t *testing.T) {
+	oid := "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	msg := lfs.UploadMessage{Event: "upload", Oid: oid}
+	payload, err := sonic.ConfigFastest.Marshal(msg)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	jobs := make(chan TransferJob, 1)
+	results := make(chan TransferResult, 1)
+	go uploadWorker(1, jobs, results)
+
+	jobs <- TransferJob{data: payload, drsClient: mockClient{registerObj: &drs.DRSObject{Name: "file.txt"}}}
+	close(jobs)
+
+	res := <-results
+	complete, ok := res.data.(lfs.CompleteMessage)
+	if !ok {
+		t.Fatalf("expected CompleteMessage, got %T", res.data)
+	}
+	if complete.Path != "file.txt" {
+		t.Fatalf("unexpected path: %s", complete.Path)
+	}
+}
+
+func TestDownloadWorker_InvalidJSON(t *testing.T) {
+	jobs := make(chan TransferJob, 1)
+	results := make(chan TransferResult, 1)
+	go downloadWorker(1, jobs, results)
+
+	jobs <- TransferJob{data: []byte("bad"), drsClient: mockClient{}}
+	close(jobs)
+
+	res := <-results
+	if res.isError == false {
+		t.Fatalf("expected error result")
+	}
+}
+
+func TestUploadWorker_InvalidJSON(t *testing.T) {
+	jobs := make(chan TransferJob, 1)
+	results := make(chan TransferResult, 1)
+	go uploadWorker(1, jobs, results)
+
+	jobs <- TransferJob{data: []byte("bad"), drsClient: mockClient{}}
+	close(jobs)
+
+	res := <-results
+	if res.isError == false {
+		t.Fatalf("expected error result")
+	}
+}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,118 @@
+package config
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	anvil_client "github.com/calypr/git-drs/client/anvil"
+	"gopkg.in/yaml.v3"
+)
+
+func setupTestRepo(t *testing.T) string {
+	t.Helper()
+
+	tmpDir := t.TempDir()
+	cmd := exec.Command("git", "init", tmpDir)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git init failed: %v: %s", err, string(out))
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(cwd)
+	})
+
+	return tmpDir
+}
+
+func TestUpdateRemoteAndLoadConfig(t *testing.T) {
+	setupTestRepo(t)
+
+	remote := RemoteSelect{
+		Anvil: &anvil_client.AnvilRemote{Endpoint: "https://anvil.example", Auth: anvil_client.AnvilAuth{TerraProject: "terra"}},
+	}
+	cfg, err := UpdateRemote(Remote("origin"), remote)
+	if err != nil {
+		t.Fatalf("UpdateRemote error: %v", err)
+	}
+	if cfg.DefaultRemote != Remote("origin") {
+		t.Fatalf("expected default remote set, got %s", cfg.DefaultRemote)
+	}
+
+	loaded, err := LoadConfig()
+	if err != nil {
+		t.Fatalf("LoadConfig error: %v", err)
+	}
+	if _, ok := loaded.Remotes[Remote("origin")]; !ok {
+		t.Fatalf("expected remote in loaded config")
+	}
+}
+
+func TestLoadConfigMissing(t *testing.T) {
+	setupTestRepo(t)
+	if _, err := LoadConfig(); err == nil {
+		t.Fatalf("expected error when config missing")
+	}
+}
+
+func TestLoadConfigRequiresDefaultRemote(t *testing.T) {
+	repo := setupTestRepo(t)
+	configDir := filepath.Join(repo, ".drs")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+	configPath := filepath.Join(configDir, "config.yaml")
+	file, err := os.Create(configPath)
+	if err != nil {
+		t.Fatalf("create config: %v", err)
+	}
+	defer file.Close()
+
+	cfg := Config{Remotes: map[Remote]RemoteSelect{
+		Remote("origin"): {Anvil: &anvil_client.AnvilRemote{Endpoint: "https://anvil.example", Auth: anvil_client.AnvilAuth{TerraProject: "terra"}}},
+	}}
+	if err := yaml.NewEncoder(file).Encode(cfg); err != nil {
+		t.Fatalf("encode config: %v", err)
+	}
+
+	if _, err := LoadConfig(); err == nil {
+		t.Fatalf("expected error for missing default_remote")
+	}
+}
+
+func TestCreateEmptyConfigAndSave(t *testing.T) {
+	setupTestRepo(t)
+	if err := CreateEmptyConfig(); err != nil {
+		t.Fatalf("CreateEmptyConfig error: %v", err)
+	}
+
+	cfg := &Config{DefaultRemote: Remote("origin"), Remotes: map[Remote]RemoteSelect{}}
+	if err := SaveConfig(cfg); err != nil {
+		t.Fatalf("SaveConfig error: %v", err)
+	}
+	loaded, err := LoadConfig()
+	if err != nil {
+		t.Fatalf("LoadConfig error: %v", err)
+	}
+	if loaded.DefaultRemote != Remote("origin") {
+		t.Fatalf("unexpected default remote: %s", loaded.DefaultRemote)
+	}
+}
+
+func TestGetRemoteOrDefault(t *testing.T) {
+	cfg := Config{DefaultRemote: Remote("origin")}
+	if remote, err := cfg.GetRemoteOrDefault(""); err != nil || remote != Remote("origin") {
+		t.Fatalf("expected default remote, got %s (%v)", remote, err)
+	}
+	if remote, err := cfg.GetRemoteOrDefault("other"); err != nil || remote != Remote("other") {
+		t.Fatalf("expected provided remote, got %s (%v)", remote, err)
+	}
+}

--- a/drs/object_test.go
+++ b/drs/object_test.go
@@ -1,0 +1,45 @@
+package drs
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/calypr/git-drs/drs/hash"
+)
+
+func TestConvertOutputObjectToDRSObject(t *testing.T) {
+	input := &OutputObject{
+		Id:          "object-1",
+		Name:        "object-name",
+		SelfURI:     "drs://example/object-1",
+		Size:        42,
+		CreatedTime: "2024-01-01T00:00:00Z",
+		Checksums: []hash.Checksum{
+			{Checksum: "sha-256", Type: hash.ChecksumTypeSHA256},
+			{Checksum: "md5-value", Type: hash.ChecksumTypeMD5},
+		},
+		AccessMethods: []AccessMethod{{Type: "https"}},
+		Description:   "example",
+		Aliases:       []string{"alias-1"},
+	}
+
+	got := ConvertOutputObjectToDRSObject(input)
+	if got == nil {
+		t.Fatalf("expected non-nil object")
+	}
+	if got.Id != input.Id || got.Name != input.Name || got.Size != input.Size {
+		t.Fatalf("field mismatch: %+v", got)
+	}
+	if got.Checksums.SHA256 != "sha-256" || got.Checksums.MD5 != "md5-value" {
+		t.Fatalf("checksum conversion mismatch: %+v", got.Checksums)
+	}
+	if !reflect.DeepEqual(got.Aliases, input.Aliases) {
+		t.Fatalf("aliases mismatch: %+v", got.Aliases)
+	}
+}
+
+func TestConvertOutputObjectToDRSObjectNil(t *testing.T) {
+	if ConvertOutputObjectToDRSObject(nil) != nil {
+		t.Fatalf("expected nil result")
+	}
+}

--- a/drs/store_test.go
+++ b/drs/store_test.go
@@ -1,0 +1,96 @@
+package drs
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/bytedance/sonic"
+	"github.com/calypr/git-drs/drs/hash"
+	"github.com/calypr/git-drs/drslog"
+)
+
+func setupTempRepo(t *testing.T) string {
+	t.Helper()
+	repo := t.TempDir()
+	cmd := exec.Command("git", "init", repo)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git init failed: %v: %s", err, string(out))
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd failed: %v", err)
+	}
+	if err := os.Chdir(repo); err != nil {
+		t.Fatalf("chdir failed: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(cwd)
+	})
+	return repo
+}
+
+func TestGetPendingObjects(t *testing.T) {
+	setupTempRepo(t)
+	objectsDir := filepath.Join(".drs", "lfs", "objects", "aa", "bb")
+	if err := os.MkdirAll(objectsDir, 0o755); err != nil {
+		t.Fatalf("mkdir failed: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(objectsDir, "oid-1"), []byte(""), 0o644); err != nil {
+		t.Fatalf("write file failed: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(".drs", "lfs", "objects", "aa", "oid-2"), []byte(""), 0o644); err != nil {
+		t.Fatalf("write malformed file failed: %v", err)
+	}
+
+	logger := drslog.NewNoOpLogger()
+	objects, err := GetPendingObjects(logger)
+	if err != nil {
+		t.Fatalf("GetPendingObjects error: %v", err)
+	}
+	if len(objects) != 1 {
+		t.Fatalf("expected 1 pending object, got %d", len(objects))
+	}
+	if objects[0].OID != "oid-1" {
+		t.Fatalf("expected OID oid-1, got %s", objects[0].OID)
+	}
+}
+
+func TestGetDrsLfsObjects(t *testing.T) {
+	setupTempRepo(t)
+	objectsDir := filepath.Join(".drs", "lfs", "objects", "aa", "bb")
+	if err := os.MkdirAll(objectsDir, 0o755); err != nil {
+		t.Fatalf("mkdir failed: %v", err)
+	}
+	payload := DRSObject{
+		Id:        "object-1",
+		Name:      "object-one",
+		Checksums: hash.HashInfo{SHA256: "sha-256-value"},
+	}
+	data, err := sonic.ConfigFastest.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(objectsDir, "oid-1"), data, 0o644); err != nil {
+		t.Fatalf("write file failed: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(objectsDir, "bad-json"), []byte("{invalid"), 0o644); err != nil {
+		t.Fatalf("write invalid json failed: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(".drs", "lfs", "objects", "aa", "oid-2"), data, 0o644); err != nil {
+		t.Fatalf("write malformed file failed: %v", err)
+	}
+
+	logger := drslog.NewNoOpLogger()
+	objects, err := GetDrsLfsObjects(logger)
+	if err != nil {
+		t.Fatalf("GetDrsLfsObjects error: %v", err)
+	}
+	if len(objects) != 1 {
+		t.Fatalf("expected 1 drs object, got %d", len(objects))
+	}
+	if _, ok := objects["sha-256-value"]; !ok {
+		t.Fatalf("expected sha-256-value key")
+	}
+}

--- a/drs/util_test.go
+++ b/drs/util_test.go
@@ -1,0 +1,50 @@
+package drs
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/bytedance/sonic"
+	"github.com/calypr/git-drs/drs/hash"
+)
+
+func TestObjectWalk(t *testing.T) {
+	setupTempRepo(t)
+	baseDir := filepath.Join(".drs", "objects")
+	if err := os.MkdirAll(baseDir, 0o755); err != nil {
+		t.Fatalf("mkdir failed: %v", err)
+	}
+	obj := DRSObject{
+		Id:        "object-1",
+		Name:      "object-name",
+		Checksums: hash.HashInfo{SHA256: "sha-256"},
+	}
+	data, err := sonic.ConfigFastest.Marshal(obj)
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+	filePath := filepath.Join(baseDir, "item.json")
+	if err := os.WriteFile(filePath, data, 0o644); err != nil {
+		t.Fatalf("write file failed: %v", err)
+	}
+
+	var seenPath string
+	var seenID string
+	err = ObjectWalk(func(path string, d *DRSObject) error {
+		seenPath = path
+		if d != nil {
+			seenID = d.Id
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("ObjectWalk error: %v", err)
+	}
+	if seenPath != filepath.Join("objects", "item.json") {
+		t.Fatalf("unexpected path %s", seenPath)
+	}
+	if seenID != "object-1" {
+		t.Fatalf("unexpected id %s", seenID)
+	}
+}

--- a/drslog/logger_test.go
+++ b/drslog/logger_test.go
@@ -1,0 +1,48 @@
+package drslog
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestNewLoggerAndClose(t *testing.T) {
+	tmp := t.TempDir()
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(tmp); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(cwd)
+	})
+
+	logger, err := NewLogger("", false)
+	if err != nil {
+		t.Fatalf("NewLogger error: %v", err)
+	}
+	logger.Printf("hello %s", "world")
+	logger.Print("line")
+	logger.Println("another")
+
+	logPath := filepath.Join(".drs", "git-drs.log")
+	if _, err := os.Stat(logPath); err != nil {
+		t.Fatalf("expected log file: %v", err)
+	}
+
+	Close()
+}
+
+func TestGetLoggerFallback(t *testing.T) {
+	logger := GetLogger()
+	if logger == nil {
+		t.Fatalf("expected logger")
+	}
+}
+
+func TestNewNoOpLogger(t *testing.T) {
+	logger := NewNoOpLogger()
+	logger.Print("noop")
+}

--- a/drsmap/drs_map_test.go
+++ b/drsmap/drs_map_test.go
@@ -1,0 +1,83 @@
+package drsmap
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/calypr/git-drs/drs"
+	"github.com/calypr/git-drs/drs/hash"
+)
+
+func setupTestRepo(t *testing.T) {
+	t.Helper()
+
+	tmpDir := t.TempDir()
+	cmd := exec.Command("git", "init", tmpDir)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git init failed: %v: %s", err, string(out))
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(cwd)
+	})
+}
+
+func TestWriteAndReadDrsObject(t *testing.T) {
+	setupTestRepo(t)
+	oid := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	path, err := GetObjectPath(".drs/lfs/objects", oid)
+	if err != nil {
+		t.Fatalf("GetObjectPath error: %v", err)
+	}
+
+	obj := &drs.DRSObject{
+		Id:        "did-1",
+		Name:      "file.txt",
+		Checksums: hash.HashInfo{SHA256: oid},
+	}
+
+	if err := WriteDrsObj(obj, oid, path); err != nil {
+		t.Fatalf("WriteDrsObj error: %v", err)
+	}
+
+	read, err := DrsInfoFromOid(oid)
+	if err != nil {
+		t.Fatalf("DrsInfoFromOid error: %v", err)
+	}
+	if read.Id != "did-1" {
+		t.Fatalf("unexpected object: %+v", read)
+	}
+}
+
+func TestGetObjectPathValidation(t *testing.T) {
+	if _, err := GetObjectPath(".drs/lfs/objects", "short"); err == nil {
+		t.Fatalf("expected error for invalid oid")
+	}
+}
+
+func TestDrsUUIDDeterministic(t *testing.T) {
+	id1 := DrsUUID("project", "hash")
+	id2 := DrsUUID("project", "hash")
+	if id1 != id2 {
+		t.Fatalf("expected deterministic UUIDs, got %s vs %s", id1, id2)
+	}
+}
+
+func TestGetObjectPathLayout(t *testing.T) {
+	oid := "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	path, err := GetObjectPath("base", oid)
+	if err != nil {
+		t.Fatalf("GetObjectPath error: %v", err)
+	}
+	if filepath.Base(path) != oid {
+		t.Fatalf("unexpected path: %s", path)
+	}
+}

--- a/drsmap/lfs_utils_test.go
+++ b/drsmap/lfs_utils_test.go
@@ -1,0 +1,42 @@
+package drsmap
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/calypr/git-drs/drs"
+	"github.com/calypr/git-drs/drs/hash"
+)
+
+func TestCreateLfsPointer(t *testing.T) {
+	obj := &drs.DRSObject{
+		Size:      10,
+		Checksums: hash.HashInfo{SHA256: "abc"},
+	}
+	path := filepath.Join(t.TempDir(), "pointer")
+	if err := CreateLfsPointer(obj, path); err != nil {
+		t.Fatalf("CreateLfsPointer error: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read pointer: %v", err)
+	}
+	if len(data) == 0 {
+		t.Fatalf("expected pointer content")
+	}
+}
+
+func TestCreateLfsPointer_NoChecksum(t *testing.T) {
+	obj := &drs.DRSObject{}
+	if err := CreateLfsPointer(obj, filepath.Join(t.TempDir(), "pointer")); err == nil {
+		t.Fatalf("expected error for missing checksums")
+	}
+}
+
+func TestCreateLfsPointer_NoSHA256(t *testing.T) {
+	obj := &drs.DRSObject{Checksums: hash.HashInfo{MD5: "md5"}}
+	if err := CreateLfsPointer(obj, filepath.Join(t.TempDir(), "pointer")); err == nil {
+		t.Fatalf("expected error for missing sha256")
+	}
+}

--- a/drsmap/resolve_test.go
+++ b/drsmap/resolve_test.go
@@ -1,0 +1,37 @@
+package drsmap
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/calypr/git-drs/drslog"
+)
+
+func TestResolveRemoteAndRef_Defaults(t *testing.T) {
+	tmp := t.TempDir()
+	cmd := exec.Command("git", "init", tmp)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git init failed: %v: %s", err, string(out))
+	}
+
+	logger := drslog.NewNoOpLogger()
+	spec, err := ResolveRemoteAndRef(context.Background(), tmp, "origin", logger)
+	if err != nil {
+		t.Fatalf("ResolveRemoteAndRef error: %v", err)
+	}
+	if spec.Remote != "origin" {
+		t.Fatalf("expected origin remote, got %s", spec.Remote)
+	}
+	if spec.Ref != "HEAD" {
+		t.Fatalf("expected HEAD ref, got %s", spec.Ref)
+	}
+}
+
+func TestRunGit_Error(t *testing.T) {
+	logger := drslog.NewNoOpLogger()
+	if _, err := runGit(context.Background(), os.TempDir(), logger, "unknown-command"); err == nil {
+		t.Fatalf("expected error for bad git command")
+	}
+}

--- a/lfs/messages_test.go
+++ b/lfs/messages_test.go
@@ -1,0 +1,43 @@
+package lfs
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/bytedance/sonic"
+	"github.com/bytedance/sonic/encoder"
+)
+
+func TestWriteMessages(t *testing.T) {
+	buf := &bytes.Buffer{}
+	enc := encoder.NewStreamEncoder(buf)
+
+	WriteInitErrorMessage(enc, 400, "bad")
+	var initErr InitErrorMessage
+	if err := sonic.ConfigFastest.Unmarshal(buf.Bytes(), &initErr); err != nil {
+		t.Fatalf("unmarshal init error: %v", err)
+	}
+	if initErr.Error.Code != 400 {
+		t.Fatalf("unexpected code: %d", initErr.Error.Code)
+	}
+
+	buf.Reset()
+	WriteErrorMessage(enc, "oid", 500, "fail")
+	var errMsg ErrorMessage
+	if err := sonic.ConfigFastest.Unmarshal(buf.Bytes(), &errMsg); err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+	if errMsg.Oid != "oid" || errMsg.Error.Code != 500 {
+		t.Fatalf("unexpected error message: %+v", errMsg)
+	}
+
+	buf.Reset()
+	WriteCompleteMessage(enc, "oid", "path")
+	var complete CompleteMessage
+	if err := sonic.ConfigFastest.Unmarshal(buf.Bytes(), &complete); err != nil {
+		t.Fatalf("unmarshal complete: %v", err)
+	}
+	if complete.Path != "path" || complete.Oid != "oid" {
+		t.Fatalf("unexpected complete message: %+v", complete)
+	}
+}

--- a/s3_utils/download_test.go
+++ b/s3_utils/download_test.go
@@ -1,0 +1,42 @@
+package s3_utils
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDownloadSignedUrl(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("content"))
+	}))
+	defer server.Close()
+
+	dst := filepath.Join(t.TempDir(), "file.txt")
+	if err := DownloadSignedUrl(server.URL, dst); err != nil {
+		t.Fatalf("DownloadSignedUrl error: %v", err)
+	}
+	data, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("read file: %v", err)
+	}
+	if string(data) != "content" {
+		t.Fatalf("unexpected file content: %s", string(data))
+	}
+}
+
+func TestDownloadSignedUrl_Error(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte("bad"))
+	}))
+	defer server.Close()
+
+	dst := filepath.Join(t.TempDir(), "file.txt")
+	if err := DownloadSignedUrl(server.URL, dst); err == nil {
+		t.Fatalf("expected error")
+	}
+}

--- a/s3_utils/s3_test.go
+++ b/s3_utils/s3_test.go
@@ -1,0 +1,40 @@
+package s3_utils
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/calypr/git-drs/drslog"
+)
+
+func TestCustomEndpointResolver(t *testing.T) {
+	resolver := &CustomEndpointResolver{Endpoint: "https://s3.example.com"}
+	endpoint, err := resolver.ResolveEndpoint("s3", "us-east-1")
+	if err != nil {
+		t.Fatalf("ResolveEndpoint error: %v", err)
+	}
+	if endpoint.URL != "https://s3.example.com" {
+		t.Fatalf("unexpected endpoint: %s", endpoint.URL)
+	}
+	if endpoint.Source == aws.EndpointSourceCustom {
+		// allow default value
+	}
+}
+
+func TestAddURLOptions(t *testing.T) {
+	cfg := &AddURLConfig{}
+
+	s3Client := &s3.Client{}
+	httpClient := &http.Client{}
+	logger := drslog.NewNoOpLogger()
+
+	WithS3Client(s3Client)(cfg)
+	WithHTTPClient(httpClient)(cfg)
+	WithLogger(logger)(cfg)
+
+	if cfg.S3Client != s3Client || cfg.HttpClient != httpClient || cfg.Logger != logger {
+		t.Fatalf("unexpected config: %+v", cfg)
+	}
+}

--- a/s3_utils/validate_test.go
+++ b/s3_utils/validate_test.go
@@ -1,0 +1,14 @@
+package s3_utils
+
+import "testing"
+
+func TestValidateInputs(t *testing.T) {
+	err := ValidateInputs("s3://bucket/path", "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
+	if err != nil {
+		t.Fatalf("ValidateInputs error: %v", err)
+	}
+
+	if err := ValidateInputs("http://bucket/path", "bad"); err == nil {
+		t.Fatalf("expected error for invalid inputs")
+	}
+}

--- a/tests/integration/calypr/README.md
+++ b/tests/integration/calypr/README.md
@@ -1,0 +1,70 @@
+# End-to-End Integration Test - git-drs
+
+Location: `tests/integration/calypr/end_to_end_test.go`
+
+## Overview
+
+This integration test exercises a full git + Git LFS + git-drs workflow against a GitHub Enterprise Server (GHE) instance. It creates a temporary repo, configures LFS, adds a test file, attempts pushes/pulls using `git-drs`, and verifies local object storage paths and cleanup.
+
+## What it validates
+
+- Repository creation and deletion on the GHE org.
+- `git-drs` initialization and remote configuration.
+- Git LFS tracking and pointer/file handling.
+- Detection and mapping of LFS objects via `drsmap.GetAllLfsFiles`.
+- Basic push/pull behavior against a dummy DRS endpoint.
+- Cleanup of created local repos and cloned copies.
+
+## Prerequisites
+
+- macOS (developer environment)
+- Go toolchain (project uses Go modules)
+- Binaries on `PATH`:
+  - `git`
+  - `git-lfs`
+  - `git-drs`
+  - `calypr_admin`
+- Network access to the target GHE instance.
+- A GitHub Personal Access Token (PAT) with permissions to create and delete repos in the target org.
+
+## Required environment variables
+
+- `GH_PAT` — GitHub Personal Access Token used to create/delete repos.
+- `GIT_DRS_REMOTE` — name of the profile/remote used by the project (expected by config loader).
+
+Example:
+```bash
+export GH_PAT="ghp_..."
+export GIT_DRS_REMOTE="my-profile"
+```
+
+## Running the test
+
+From the project root, run:
+
+```bash
+go test ./tests/integration/calypr -v -run TestEndToEndGitDRSWorkflow
+```
+
+Notes:
+- The test is destructive on the GHE org (creates and removes a repository). Ensure the token and org are appropriate.
+- The test runs external commands and will fail if required binaries are missing or not on `PATH`.
+- The test prints temporary directories and command outputs to help debugging.
+
+## Expected behavior
+
+- The test should create a repo named `test-<random>` under the configured org, add a single LFS-tracked file, and exercise `git-drs` commands.
+- `drsmap.GetAllLfsFiles` should return a single LFS file entry for the created test file.
+- The test will attempt `git push`/`git lfs pull` which may fail against a dummy DRS server; failures are expected and asserted accordingly in the test.
+
+## Troubleshooting
+
+- Missing binaries: ensure required tools are installed and discoverable via `which <tool>`.
+- Permission errors from GHE: verify `GH_PAT` scopes (repo creation/deletion) and that the token is valid.
+- If the test fails while cleaning up, manually check and delete the temporary repo in the org.
+- For verbose debugging, run the test with `-v` (already recommended).
+
+## Safety & CI
+
+- Consider running this test in an isolated org or a test GHE instance.
+- Run in CI only if the runner has network access and safe permissions.

--- a/utils/common_test.go
+++ b/utils/common_test.go
@@ -1,0 +1,27 @@
+package utils
+
+import "testing"
+
+func TestProjectToResource(t *testing.T) {
+	resource, err := ProjectToResource("prog-project")
+	if err != nil {
+		t.Fatalf("ProjectToResource error: %v", err)
+	}
+	if resource != "/programs/prog/projects/project" {
+		t.Fatalf("unexpected resource: %s", resource)
+	}
+
+	if _, err := ProjectToResource("invalid"); err == nil {
+		t.Fatalf("expected error for invalid project")
+	}
+}
+
+func TestAddUnique(t *testing.T) {
+	out := AddUnique([]string{"a", "b"}, []string{"b", "c"})
+	if len(out) != 3 {
+		t.Fatalf("expected 3 unique items, got %d", len(out))
+	}
+	if out[2] != "c" {
+		t.Fatalf("expected new item appended, got %v", out)
+	}
+}

--- a/utils/confirmation_test.go
+++ b/utils/confirmation_test.go
@@ -1,0 +1,61 @@
+package utils
+
+import (
+	"bytes"
+	"os"
+	"testing"
+)
+
+func TestPromptForConfirmation(t *testing.T) {
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	_, _ = writer.WriteString("YES\n")
+	_ = writer.Close()
+
+	oldStdin := os.Stdin
+	os.Stdin = reader
+	t.Cleanup(func() {
+		os.Stdin = oldStdin
+		_ = reader.Close()
+	})
+
+	buf := &bytes.Buffer{}
+	if err := PromptForConfirmation(buf, "Confirm", "yes", false); err != nil {
+		t.Fatalf("PromptForConfirmation error: %v", err)
+	}
+}
+
+func TestPromptForConfirmation_Mismatch(t *testing.T) {
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	_, _ = writer.WriteString("no\n")
+	_ = writer.Close()
+
+	oldStdin := os.Stdin
+	os.Stdin = reader
+	t.Cleanup(func() {
+		os.Stdin = oldStdin
+		_ = reader.Close()
+	})
+
+	buf := &bytes.Buffer{}
+	if err := PromptForConfirmation(buf, "Confirm", "yes", true); err == nil {
+		t.Fatalf("expected mismatch error")
+	}
+}
+
+func TestDisplayHelpers(t *testing.T) {
+	buf := &bytes.Buffer{}
+	DisplayWarningHeader(buf, "delete files")
+	DisplayField(buf, "Key", "Value")
+	DisplayFooter(buf)
+
+	out := buf.String()
+	if out == "" || !bytes.Contains([]byte(out), []byte("WARNING")) {
+		t.Fatalf("unexpected output: %s", out)
+	}
+}

--- a/utils/util_test.go
+++ b/utils/util_test.go
@@ -1,0 +1,96 @@
+package utils
+
+import (
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+func TestParseEmailFromToken(t *testing.T) {
+	claims := jwt.MapClaims{
+		"context": map[string]any{
+			"user": map[string]any{
+				"name": "user@example.com",
+			},
+		},
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	tokenString, err := token.SignedString([]byte("secret"))
+	if err != nil {
+		t.Fatalf("sign token: %v", err)
+	}
+
+	email, err := ParseEmailFromToken(tokenString)
+	if err != nil {
+		t.Fatalf("ParseEmailFromToken error: %v", err)
+	}
+	if email != "user@example.com" {
+		t.Fatalf("expected user@example.com, got %s", email)
+	}
+}
+
+func TestParseAPIEndpointFromToken(t *testing.T) {
+	claims := jwt.MapClaims{
+		"iss": "https://api.example.com/auth",
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	tokenString, err := token.SignedString([]byte("secret"))
+	if err != nil {
+		t.Fatalf("sign token: %v", err)
+	}
+
+	endpoint, err := ParseAPIEndpointFromToken(tokenString)
+	if err != nil {
+		t.Fatalf("ParseAPIEndpointFromToken error: %v", err)
+	}
+	if endpoint != "https://api.example.com" {
+		t.Fatalf("expected https://api.example.com, got %s", endpoint)
+	}
+}
+
+func TestParseS3URL(t *testing.T) {
+	bucket, key, err := ParseS3URL("s3://my-bucket/path/to/file.txt")
+	if err != nil {
+		t.Fatalf("ParseS3URL error: %v", err)
+	}
+	if bucket != "my-bucket" || key != "path/to/file.txt" {
+		t.Fatalf("unexpected bucket/key: %s/%s", bucket, key)
+	}
+}
+
+func TestGitTopLevelAndSimpleRun(t *testing.T) {
+	tmp := t.TempDir()
+	cmd := exec.Command("git", "init", tmp)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git init failed: %v: %s", err, string(out))
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(tmp); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(cwd)
+	})
+
+	top, err := GitTopLevel()
+	if err != nil {
+		t.Fatalf("GitTopLevel error: %v", err)
+	}
+	if top != tmp {
+		t.Fatalf("expected top %s, got %s", tmp, top)
+	}
+
+	out, err := SimpleRun([]string{"git", "rev-parse", "--show-toplevel"})
+	if err != nil {
+		t.Fatalf("SimpleRun error: %v", err)
+	}
+	if out == "" {
+		t.Fatalf("expected output")
+	}
+}


### PR DESCRIPTION
## Motivation

* See #130
* Improve test coverage across core flows (indexd client, transfer workers, DRS helpers, config, and utilities).
* Add coverage for key success/error paths to reduce regressions.

## Description
* Add unit tests for indexd client conversions, auth handling, and HTTP flows.
* Add command helper tests for add-url, initialize, list, and transfer workflows.
* Add tests for drs/drsmap object helpers, LFS message writers, s3 utilities, logging, and common utils.

## Testing
```
go test -v -race -coverprofile=coverage.out -covermode=atomic -coverpkg=./... $(go list ./... | grep -vE 'tests/integration/calypr|client/indexd/tests') (run to validate coverage and correctness)
```

## Adds missing documentation

### Summary
- Add documentation describing how to run and troubleshoot tests in `client/indexd/tests`.
- Add documentation describing how to run and troubleshoot tests in `tests/integration/calypr`.

### Motivation
- Improve developer onboarding and make it easier to run and debug unit/integration tests related to the indexd client.
- Reduce accidental use of production credentials or destructive operations by calling out safety and environment requirements.


