### PR TITLE
bug/git-drs-list-marshall-error #148

### DIFF
--- a/drs/hash/hash_test.go
+++ b/drs/hash/hash_test.go
@@ -1,6 +1,7 @@
 package hash
 
 import (
+	"encoding/json"
 	"reflect"
 	"testing"
 )
@@ -275,5 +276,26 @@ func TestConvertChecksumsToHashInfo(t *testing.T) {
 				t.Errorf("ConvertChecksumsToHashInfo() got = %+v, want %+v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestHashInfoUnmarshalJSONChecksumsArray(t *testing.T) {
+	payload := []byte(`[
+		{"checksum":"8f200381b52333426dcad04771eb18f1","type":"md5"},
+		{"checksum":"3d0658efb439683ae9649c6213299219","type":"sha256"}
+	]`)
+
+	var got HashInfo
+	if err := json.Unmarshal(payload, &got); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+
+	want := HashInfo{
+		MD5:    "8f200381b52333426dcad04771eb18f1",
+		SHA256: "3d0658efb439683ae9649c6213299219",
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("json.Unmarshal() got = %+v, want %+v", got, want)
 	}
 }


### PR DESCRIPTION
## summary
DRS responses can encode checksums as arrays of {checksum,type} entries, which previously failed to unmarshal into HashInfo.

See #148  🌂 Please close this issue when merged

## description

Added custom JSON unmarshalling for HashInfo to accept both map-based and array-based checksum payloads using existing conversion helpers.

Added a unit test verifying checksum-array unmarshalling into HashInfo.

## testing

### unit
```
$  go test -v -race $(go list ./... | grep -v 'tests/integration/calypr' | grep -v 'client/indexd/tests') | grep TestHashInfoUnmarshalJSONChecksumsArray
=== RUN   TestHashInfoUnmarshalJSONChecksumsArray
--- PASS: TestHashInfoUnmarshalJSONChecksumsArray (0.00s)
```

### integration 
```
$ git drs list | head -10
[134] 2026/01/14 15:50:14 indexd_client.go:777: Getting DRS objects from indexd
URI                                                     Size            Checksum                                                                        Name
[134] 2026/01/14 15:50:14 client.go:680: [DEBUG] GET https://calypr-dev.ohsu.edu/ga4gh/drs/v1/objects?limit=50&page=0
drs://PREFIX:3fc29461-775e-5cf9-a174-88945c534711       6613996         md5:8f200381b52333426dcad04771eb18f1                                            _cbds-smmart_labkey_demo-20241008-131545_meta.zip
drs://PREFIX:77e28faf-b3ab-5523-902c-4a8712e7078e       6072715         md5:3d0658efb439683ae9649c6213299219                                            cbds-smmart_labkey_demo_20241008-201635_SNAPSHOT.zip
drs://PREFIX:a74a1776-be34-5c05-9709-c7c52c11713e       6613996         md5:8f200381b52333426dcad04771eb18f1                                            _cbds-smmart_labkey_demo-20241008-132240_meta.zip
drs://PREFIX:88ba54bb-9b94-585d-9660-ae90e1296f6c       6727507         md5:15da10a50f9176bc6881d0617e4d2e61                                            cbds-smmart_labkey_demo_20241008-202300_SNAPSHOT.zip
drs://PREFIX:ebc05641-ae0d-58c0-920d-b1edb1d6735f       830327          md5:b9de3f668557f797765bf0aa49def30a                                            _cbds-gdc_esca-20241008-134324_meta.zip
drs://PREFIX:7d92be80-edcf-53b3-82ce-b568efbea746       830447          md5:1f36ae28e7c2e1cd2abb45bd5a46016b                                            cbds-gdc_esca_20241008-204327_SNAPSHOT.zip
drs://PREFIX:becd0f68-7ca4-5f1d-976a-ef954d22a37c       171112          md5:36b3ef3282bbc902effc7a00db43b3d0                                            _cbds-gdc_lung-20241008-140256_meta.zip
drs://PREFIX:b319d855-208d-548e-8b3e-b720469f894b       171232          md5:87539fec21de5213f7d885651a7309ad                                            cbds-gdc_lung_20241008-210257_SNAPSHOT.zip
drs://PREFIX:06286ce4-fd75-5c08-8deb-da120198fa26       171112          md5:36b3ef3282bbc902effc7a00db43b3d0                                            _cbds-gdc_lung-20241008-140648_meta.zip

```



