### PR TITLE
bug/version-hard-coded #154

### DIFF
--- a/cmd/version/main.go
+++ b/cmd/version/main.go
@@ -2,6 +2,7 @@ package version
 
 import (
 	"fmt"
+	"runtime/debug"
 
 	"github.com/spf13/cobra"
 )
@@ -12,7 +13,42 @@ var Cmd = &cobra.Command{
 	Short: "Get version",
 	Long:  ``,
 	Run: func(cmd *cobra.Command, args []string) {
-		var version = "0.5.0"
-		fmt.Println("git-drs", version)
+		fmt.Println("git-drs", buildVersion())
 	},
+}
+
+func buildVersion() string {
+	tag := ""
+	commit := ""
+	if info, ok := debug.ReadBuildInfo(); ok {
+		if info.Main.Version != "" && info.Main.Version != "(devel)" {
+			tag = info.Main.Version
+		}
+		for _, setting := range info.Settings {
+			switch setting.Key {
+			case "vcs.revision":
+				commit = setting.Value
+			case "vcs.tag":
+				if tag == "" {
+					tag = setting.Value
+				}
+			}
+		}
+	}
+
+	commitShort := commit
+	if len(commitShort) > 7 {
+		commitShort = commitShort[:7]
+	}
+
+	switch {
+	case tag != "" && commitShort != "":
+		return fmt.Sprintf("%s-%s", tag, commitShort)
+	case tag != "":
+		return tag
+	case commitShort != "":
+		return fmt.Sprintf("dev-%s", commitShort)
+	default:
+		return "dev-unknown"
+	}
 }

--- a/cmd/version/version_test.go
+++ b/cmd/version/version_test.go
@@ -119,3 +119,11 @@ func TestVersionCommand_Output(t *testing.T) {
 		})
 	}
 }
+
+func TestBuildVersion(t *testing.T) {
+	version := buildVersion()
+	assert.NotEmpty(t, version, "build version should not be empty")
+
+	hasSeparator := strings.Contains(version, ".") || strings.Contains(version, "-")
+	assert.True(t, hasSeparator, "version should include a separator")
+}


### PR DESCRIPTION
## Summary
Replace the hard-coded CLI version string with build metadata (tag + short commit) derived from Go build info.

Add a unit test to ensure buildVersion() returns a non-empty, formatted version string.

See #154


## Motivation
The version command should reflect the actual build provenance instead of a fixed string. This change ensures releases report their Git tag and commit, while development builds still emit useful identifiers, and it adds basic coverage for the formatting.

## Changes
* Use debug.ReadBuildInfo() to compute the version from info.Main.Version, vcs.tag, and vcs.revision.
* Format output as tag-shortcommit, tag, dev-shortcommit, or dev-unknown.
* Add TestBuildVersion to validate non-empty output and expected separators.

## Testing

### unit

```
$ go test -v -race $(go list ./... | grep -v 'tests/integration/calypr' | grep -v 'client/indexd/tests') | grep VersionCommand
=== RUN   TestVersionCommand
=== RUN   TestVersionCommand/prints_version_with_git-drs_prefix
=== RUN   TestVersionCommand/version_string_matches_expected_format
=== RUN   TestVersionCommand/accepts_no_arguments
=== RUN   TestVersionCommand/ignores_extra_arguments_gracefully
--- PASS: TestVersionCommand (0.00s)
    --- PASS: TestVersionCommand/prints_version_with_git-drs_prefix (0.00s)
    --- PASS: TestVersionCommand/version_string_matches_expected_format (0.00s)
    --- PASS: TestVersionCommand/accepts_no_arguments (0.00s)
    --- PASS: TestVersionCommand/ignores_extra_arguments_gracefully (0.00s)
=== RUN   TestVersionCommand_Output
=== RUN   TestVersionCommand_Output/contains_git-drs_prefix
--- PASS: TestVersionCommand_Output (0.00s)
    --- PASS: TestVersionCommand_Output/contains_git-drs_prefix (0.00s)
```

### integration

```
$ git-drs version
git-drs v0.5.3-0.20260114224500-ae553e60fd4e+dirty-ae553e6
$ git drs version
git-drs v0.5.3-0.20260114224500-ae553e60fd4e+dirty-ae553e6

```


