### PR TITLE
chore/normalize-drs-config-location #149

### DIFF
--- a/cmd/initialize/main_test.go
+++ b/cmd/initialize/main_test.go
@@ -10,26 +10,6 @@ import (
 	"github.com/calypr/git-drs/internal/testutils"
 )
 
-func TestEnsureDrsObjectsIgnore(t *testing.T) {
-	testutils.SetupTestGitRepo(t)
-	logger := drslog.NewNoOpLogger()
-
-	if err := ensureDrsObjectsIgnore(".drs/objects", logger); err != nil {
-		t.Fatalf("ensureDrsObjectsIgnore error: %v", err)
-	}
-	content, err := os.ReadFile(".gitignore")
-	if err != nil {
-		t.Fatalf("read .gitignore: %v", err)
-	}
-	if !strings.Contains(string(content), ".drs/objects") {
-		t.Fatalf("expected ignore pattern in .gitignore")
-	}
-
-	if err := ensureDrsObjectsIgnore(".drs/objects", logger); err != nil {
-		t.Fatalf("ensureDrsObjectsIgnore second call error: %v", err)
-	}
-}
-
 func TestInstallPrePushHook(t *testing.T) {
 	testutils.SetupTestGitRepo(t)
 	logger := drslog.NewNoOpLogger()

--- a/cmd/prepush/main.go
+++ b/cmd/prepush/main.go
@@ -52,7 +52,7 @@ var Cmd = &cobra.Command{
 		}
 		myLogger.Printf("git remote name: %s, git remote location: %s", gitRemoteName, gitRemoteLocation)
 
-		// get the default remote from the .drs/config
+		// get the default remote from the .git/drs/config
 		var remote config.Remote
 		remote, err = cfg.GetDefaultRemote()
 		if err != nil {

--- a/cmd/register/main.go
+++ b/cmd/register/main.go
@@ -16,7 +16,7 @@ var remote string
 var Cmd = &cobra.Command{
 	Use:   "register",
 	Short: "Register all pending DRS objects with indexd",
-	Long:  "Reads pending objects from .drs/lfs/objects/ and registers them with indexd (does not upload files)",
+	Long:  "Reads pending objects from .git/drs/lfs/objects/ and registers them with indexd (does not upload files)",
 	Args: func(cmd *cobra.Command, args []string) error {
 		if len(args) != 0 {
 			cmd.SilenceUsage = false

--- a/config/config.go
+++ b/config/config.go
@@ -238,7 +238,7 @@ func LoadConfig() (*Config, error) {
 		return nil, fmt.Errorf(
 			"configuration migration required.\n\n" +
 				"Your config has remotes but no default_remote field.\n" +
-				"Add this line to .drs/config.yaml:\n\n" +
+				"Add this line to .git/drs/config.yaml:\n\n" +
 				"  default_remote: <remote-name>\n\n" +
 				"or delete and recreate the config file by re-running\n\n" +
 				"  git drs remote add \n\n",

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -65,7 +65,7 @@ func TestLoadConfigMissing(t *testing.T) {
 
 func TestLoadConfigRequiresDefaultRemote(t *testing.T) {
 	repo := setupTestRepo(t)
-	configDir := filepath.Join(repo, ".drs")
+	configDir := filepath.Join(repo, ".git", "drs")
 	if err := os.MkdirAll(configDir, 0o755); err != nil {
 		t.Fatalf("mkdir config dir: %v", err)
 	}

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -8,7 +8,7 @@ Complete reference for Git DRS and related Git LFS commands.
 
 ### `git drs init`
 
-Initialize Git DRS in a repository. Sets up Git LFS custom transfer hooks.
+Initialize Git DRS in a repository. Sets up Git LFS custom transfer hooks and creates a `.git/drs/` directory that Git ignores automatically.
 
 **Usage:**
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -8,7 +8,7 @@ Complete reference for Git DRS and related Git LFS commands.
 
 ### `git drs init`
 
-Initialize Git DRS in a repository. Sets up Git LFS custom transfer hooks and configures `.gitignore` patterns.
+Initialize Git DRS in a repository. Sets up Git LFS custom transfer hooks.
 
 **Usage:**
 
@@ -28,11 +28,9 @@ git drs init
 
 **What it does:**
 
-- Creates `.drs/` directory structure
+- Creates `.git/drs/` directory structure
 - Configures Git LFS custom transfer agent
-- Updates `.gitignore` to exclude DRS cache files
 - Installs Git hooks for DRS workflows
-- Stages `.gitignore` changes automatically
 
 **Note:** Run this before adding remotes.
 
@@ -167,7 +165,7 @@ git drs fetch production
 **What it does:**
 
 - Identifies remote and project from configuration
-- Transfers all DRS records for a given project from the server to the local `.drs/lfs/objects/` directory
+- Transfers all DRS records for a given project from the server to the local `.git/drs/lfs/objects/` directory
 
 ### `git drs push [remote-name]`
 
@@ -186,7 +184,7 @@ git drs push production
 
 **What it does:**
 
-- Checks local `.drs/lfs/objects/` for DRS metadata
+- Checks local `.git/drs/lfs/objects/` for DRS metadata
 - For each object, uploads file to bucket if file exists locally
 - If file doesn't exist locally (metadata only), registers metadata without upload
 - This enables cross-remote promotion workflows

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -32,7 +32,7 @@ Git DRS integrates with Git through several mechanisms:
 2. Developer: git commit -m "Add data"
 3. Git Hook: git drs precommit
    - Creates DRS object metadata
-   - Stores in .drs/ directory
+   - Stores in .git/drs/ directory
 4. Developer: git push
 5. Git Hook: git drs prepush
    - Updates DRS object metadata
@@ -115,7 +115,7 @@ utils/                 # Shared utilities
 
 ### Configuration System
 
-**Repository Configuration**: `.drs/config`
+**Repository Configuration**: `.git/drs/config.yaml`
 ```yaml
 current_server: gen3
 servers:
@@ -128,7 +128,7 @@ servers:
 
 ### DRS Object Management
 
-Objects are stored in `.drs/objects/` during pre-commit and referenced during transfers.
+Objects are stored in `.git/drs/lfs/objects/` during pre-commit and referenced during transfers.
 
 ## Development Setup
 
@@ -173,8 +173,8 @@ export PATH=$PATH:$(pwd)
 
 ### Log Locations
 
-- **Commit logs**: `.drs/git-drs.log`
-- **Transfer logs**: `.drs/git-drs.log`
+- **Commit logs**: `.git/drs/git-drs.log`
+- **Transfer logs**: `.git/drs/git-drs.log`
 
 
 ## Testing

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -278,7 +278,7 @@ git drs remote set staging
 
 ### View Logs
 
-- Logs location: `.drs/` directory
+- Logs location: `.git/drs/` directory
 
 ## Command Summary
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -184,7 +184,7 @@ git drs list-config
 git lfs pull -I "problematic-file*" --verbose
 
 # Check logs
-cat .drs/*.log
+cat .git/drs/*.log
 ```
 
 ### Configuration Issues
@@ -380,8 +380,8 @@ git lfs ls-files
 
 ```bash
 # Git DRS logs (in repository)
-ls -la .drs/
-cat .drs/*.log
+ls -la .git/drs/
+cat .git/drs/*.log
 ```
 
 ### Test Connectivity
@@ -410,7 +410,7 @@ git --version
 git drs remote list
 
 # Recent logs
-tail -50 .drs/*.log
+tail -50 .git/drs/*.log
 ```
 
 ## Prevention Best Practices

--- a/drs/store.go
+++ b/drs/store.go
@@ -10,13 +10,13 @@ import (
 	"github.com/calypr/git-drs/projectdir"
 )
 
-// This file contains functions that pertain to .drs/lfs/objects directory walk
+// This file contains functions that pertain to .git/drs/lfs/objects directory walk
 type PendingObject struct {
 	OID  string
 	Path string
 }
 
-// getPendingObjects walks .drs/lfs/objects/ to find all pending records
+// getPendingObjects walks .git/drs/lfs/objects/ to find all pending records
 func GetPendingObjects(logger *log.Logger) ([]*PendingObject, error) {
 	var objects []*PendingObject
 	objectsDir := projectdir.DRS_OBJS_PATH

--- a/drs/store_test.go
+++ b/drs/store_test.go
@@ -33,14 +33,14 @@ func setupTempRepo(t *testing.T) string {
 
 func TestGetPendingObjects(t *testing.T) {
 	setupTempRepo(t)
-	objectsDir := filepath.Join(".drs", "lfs", "objects", "aa", "bb")
+	objectsDir := filepath.Join(".git", "drs", "lfs", "objects", "aa", "bb")
 	if err := os.MkdirAll(objectsDir, 0o755); err != nil {
 		t.Fatalf("mkdir failed: %v", err)
 	}
 	if err := os.WriteFile(filepath.Join(objectsDir, "oid-1"), []byte(""), 0o644); err != nil {
 		t.Fatalf("write file failed: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(".drs", "lfs", "objects", "aa", "oid-2"), []byte(""), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(".git", "drs", "lfs", "objects", "aa", "oid-2"), []byte(""), 0o644); err != nil {
 		t.Fatalf("write malformed file failed: %v", err)
 	}
 
@@ -59,7 +59,7 @@ func TestGetPendingObjects(t *testing.T) {
 
 func TestGetDrsLfsObjects(t *testing.T) {
 	setupTempRepo(t)
-	objectsDir := filepath.Join(".drs", "lfs", "objects", "aa", "bb")
+	objectsDir := filepath.Join(".git", "drs", "lfs", "objects", "aa", "bb")
 	if err := os.MkdirAll(objectsDir, 0o755); err != nil {
 		t.Fatalf("mkdir failed: %v", err)
 	}
@@ -78,7 +78,7 @@ func TestGetDrsLfsObjects(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(objectsDir, "bad-json"), []byte("{invalid"), 0o644); err != nil {
 		t.Fatalf("write invalid json failed: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(".drs", "lfs", "objects", "aa", "oid-2"), data, 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(".git", "drs", "lfs", "objects", "aa", "oid-2"), data, 0o644); err != nil {
 		t.Fatalf("write malformed file failed: %v", err)
 	}
 

--- a/drs/util.go
+++ b/drs/util.go
@@ -9,7 +9,7 @@ import (
 	"github.com/calypr/git-drs/utils"
 )
 
-const DRS_DIR = ".drs"
+const DRS_DIR = ".git/drs"
 
 type DrsWalkFunc func(path string, d *DRSObject) error
 

--- a/drs/util_test.go
+++ b/drs/util_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestObjectWalk(t *testing.T) {
 	setupTempRepo(t)
-	baseDir := filepath.Join(".drs", "objects")
+	baseDir := filepath.Join(".git", "drs", "objects")
 	if err := os.MkdirAll(baseDir, 0o755); err != nil {
 		t.Fatalf("mkdir failed: %v", err)
 	}

--- a/drslog/logger_test.go
+++ b/drslog/logger_test.go
@@ -27,7 +27,7 @@ func TestNewLoggerAndClose(t *testing.T) {
 	logger.Print("line")
 	logger.Println("another")
 
-	logPath := filepath.Join(".drs", "git-drs.log")
+	logPath := filepath.Join(".git", "drs", "git-drs.log")
 	if _, err := os.Stat(logPath); err != nil {
 		t.Fatalf("expected log file: %v", err)
 	}

--- a/drsmap/drs_map.go
+++ b/drsmap/drs_map.go
@@ -77,7 +77,7 @@ type LfsFileInfo struct {
 }
 
 func PushLocalDrsObjects(drsClient client.DRSClient, myLogger *log.Logger) error {
-	// Gather all objects in .drs/lfs/objects store
+	// Gather all objects in .git/drs/lfs/objects store
 	drsLfsObjs, err := drs.GetDrsLfsObjects(myLogger)
 	if err != nil {
 		return err

--- a/drsmap/drs_map_test.go
+++ b/drsmap/drs_map_test.go
@@ -33,7 +33,7 @@ func setupTestRepo(t *testing.T) {
 func TestWriteAndReadDrsObject(t *testing.T) {
 	setupTestRepo(t)
 	oid := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-	path, err := GetObjectPath(".drs/lfs/objects", oid)
+	path, err := GetObjectPath(".git/drs/lfs/objects", oid)
 	if err != nil {
 		t.Fatalf("GetObjectPath error: %v", err)
 	}
@@ -58,7 +58,7 @@ func TestWriteAndReadDrsObject(t *testing.T) {
 }
 
 func TestGetObjectPathValidation(t *testing.T) {
-	if _, err := GetObjectPath(".drs/lfs/objects", "short"); err == nil {
+	if _, err := GetObjectPath(".git/drs/lfs/objects", "short"); err == nil {
 		t.Fatalf("expected error for invalid oid")
 	}
 }

--- a/projectdir/values.go
+++ b/projectdir/values.go
@@ -2,11 +2,11 @@ package projectdir
 
 const (
 	LFS_OBJS_PATH = ".git/lfs/objects"
-	DRS_DIR       = ".drs"
+	DRS_DIR       = ".git/drs"
 	// FIXME: should this be /lfs/objects or just /objects?
 	DRS_OBJS_PATH = DRS_DIR + "/lfs/objects"
 	CONFIG_YAML   = "config.yaml"
 
 	DRS_REF_DIR  string = ".git/drs/objects"
-	DRS_LOG_FILE string = ".drs/drs.log"
+	DRS_LOG_FILE string = ".git/drs/drs.log"
 )

--- a/tests/integration/calypr/end_to_end_test.go
+++ b/tests/integration/calypr/end_to_end_test.go
@@ -156,20 +156,20 @@ func TestEndToEndGitDRSWorkflow(t *testing.T) {
 	}
 	t.Logf("git-drs add remote output: %s", output)
 
-	// Verify .drs/config.yaml exists
-	configPath := filepath.Join(".drs", "config.yaml")
+	// Verify .git/drs/config.yaml exists
+	configPath := filepath.Join(".git", "drs", "config.yaml")
 	if _, err := os.Stat(configPath); err != nil {
 		if os.IsNotExist(err) {
-			t.Fatalf(".drs/config.yaml not created in %s", repoDir)
+			t.Fatalf(".git/drs/config.yaml not created in %s", repoDir)
 		}
-		t.Fatalf("Failed to stat .drs/config.yaml in %s: %v", repoDir, err)
+		t.Fatalf("Failed to stat .git/drs/config.yaml in %s: %v", repoDir, err)
 	}
 	// Log config.yaml contents for debugging
 	configContent, err := os.ReadFile(configPath)
 	if err != nil {
-		t.Fatalf("Failed to read .drs/config.yaml: %v", err)
+		t.Fatalf("Failed to read .git/drs/config.yaml: %v", err)
 	} else {
-		t.Logf(".drs/config.yaml contents: %s", configContent)
+		t.Logf(".git/drs/config.yaml contents: %s", configContent)
 	}
 
 	cmd = exec.Command("git", "lfs", "track", "*.txt")

--- a/tests/monorepos/README-run-test.md
+++ b/tests/monorepos/README-run-test.md
@@ -50,7 +50,7 @@ Note: We've been using https://github.com/calypr/monorepo.git
 * When initializing the fixtures repo the script:
   * creates or uses branch main,
   * runs git drs init --cred ... --profile ... --bucket calypr --project "$PROGRAM-$PROJECT" ...,
-  * ensures .drs/config.yaml exists,
+  * ensures .git/drs/config.yaml exists,
   * creates .gitattributes (if missing), commits and pushes,
   * tracks and pushes each top-level fixture subfolder with git LFS
 

--- a/tests/monorepos/run-test.sh
+++ b/tests/monorepos/run-test.sh
@@ -155,7 +155,7 @@ echo "Running in `pwd`"  >&2
 # to reset git state
 if [ "$CLEAN" = "true" ]; then
   echo "Cleaning existing git state" >&2
-  rm -rf .git .drs .gitattributes  ~/.gen3/logs/*.* lfs-console.log lfs-console-aggregate.log commit.log commit-aggregate.log
+  rm -rf .git .gitattributes  ~/.gen3/logs/*.* lfs-console.log lfs-console-aggregate.log commit.log commit-aggregate.log
 else
   echo "CLEAN flag not set to true; skipping git state cleanup" >&2
 fi
@@ -176,17 +176,13 @@ else
   git drs init -t 16
   git drs remote add gen3 "$PROFILE" --cred "$CREDENTIALS_PATH"  --bucket cbds --project "$PROGRAM-$PROJECT" --url https://calypr-dev.ohsu.edu
 
-  # verify fixtures/.drs/config.yaml exists
-  if [ ! -f ".drs/config.yaml" ]; then
-    echo "error: .drs/config.yaml not found after git drs init" >&2
+  # verify fixtures/.git/drs/config.yaml exists
+  if [ ! -f ".git/drs/config.yaml" ]; then
+    echo "error: .git/drs/config.yaml not found after git drs init" >&2
     exit 1
   fi
 
   echo "Finished initializing git repository with git-drs in `pwd`" >&2
-  git add .drs
-  git commit -m "Add .drs" .drs
-  git add .gitignore
-  git commit -m "Add .gitignore" .gitignore
 
   # Create an empty .gitattributes file
   # if .gitattributes does not already exist initialize it
@@ -225,13 +221,13 @@ for dir in */ ; do
     GIT_TRACE=1 GIT_TRANSFER_TRACE=1 git push origin main 2>&1 | tee lfs-console.log
     echo "##########################################" >> lfs-console.log
     echo "# finished pushing $dir to remote." >> lfs-console.log
-    # if .drs/lfs/objects exists, log last 3 lines of tree
-    if [ ! -d ".drs/lfs/objects" ]; then
-      echo "# .drs/lfs/objects does not exist." >> lfs-console.log
+    # if .git/drs/lfs/objects exists, log last 3 lines of tree
+    if [ ! -d ".git/drs/lfs/objects" ]; then
+      echo "# .git/drs/lfs/objects does not exist." >> lfs-console.log
       echo "##########################################" >> lfs-console.log
     else
-      echo "# Last 3 lines of .drs/lfs/objects tree:" >> lfs-console.log
-      tree .drs/lfs/objects | tail -3 >> lfs-console.log
+      echo "# Last 3 lines of .git/drs/lfs/objects tree:" >> lfs-console.log
+      tree .git/drs/lfs/objects | tail -3 >> lfs-console.log
     fi
     echo "# git lfs status:" >> lfs-console.log
     git lfs status >> lfs-console.log

--- a/tests/scripts/end-2-end/e2e.sh
+++ b/tests/scripts/end-2-end/e2e.sh
@@ -63,7 +63,6 @@ git drs remote add gen3 "$PROFILE" --cred "$CREDENTIALS_PATH"  --bucket $DEFAULT
 git lfs track "*.txt"
 
 git add .gitattributes
-git add .drs
 git config credential.helper "!f() { echo username=x-oauth-basic; echo password=${TOKEN}; }; f"
 
 git branch -M main

--- a/tests/scripts/simple-forge/end-to-end.sh
+++ b/tests/scripts/simple-forge/end-to-end.sh
@@ -37,7 +37,7 @@ echo $DATE > data/B/simple.greeting
 echo $DATE > data/C/simple.greeting
 
 git add data/
-git add .drs/config.yaml
+git add .git/drs/config.yaml
 git commit -m "Initial commit: Add .greeting files with 'hello'"
 
 # Prompt user for remote if not set

--- a/utils/common.go
+++ b/utils/common.go
@@ -6,7 +6,7 @@ import (
 )
 
 const (
-	DRS_DIR = ".drs"
+	DRS_DIR = ".git/drs"
 )
 
 func ProjectToResource(project string) (string, error) {


### PR DESCRIPTION
## Summary
See #149 

* Moved core DRS path constants to .git/drs so metadata and logs live under the Git directory instead of the repo root.
* Updated documentation to describe the new .git/drs layout and init behavior for Git DRS users.
* Adjusted tests/scripts to validate .git/drs configuration paths and object locations during workflows.

## Testing

### unit
```
$ go test -v -race $(go list ./... | grep -v 'tests/integration/calypr' | grep -v 'client/indexd/tests')  | grep FAIL || echo 'OK'
OK
```
### integration

⚠️  Please test carefully in multiple scenario.  Include clone testing, etc.
