### PR TITLE
chore/deprecate-drs-push

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ For detailed setup and usage information:
 | `git lfs ls-files`     | List tracked files                    |
 | `git lfs pull`         | Download tracked files                |
 | `git drs fetch`        | Fetch metadata from DRS server        |
-| `git drs push`         | Push objects to DRS server            |
+| `git drs push`         | Push objects to DRS server (deprecated) |
 
 Use `--help` with any command for details. See [Commands Reference](docs/commands.md) for complete documentation.
 

--- a/cmd/push/main.go
+++ b/cmd/push/main.go
@@ -13,6 +13,7 @@ var Cmd = &cobra.Command{
 	Use:   "push [remote-name]",
 	Short: "push local objects to drs server.",
 	Long:  "push local objects to drs server. Any local files that do not have drs records are written to a bucket.",
+	Deprecated: "use `git push` (with the installed pre-push hook) for uploads and `git drs fetch` for cross-remote metadata promotion; `git drs push` will be removed in a future release",
 	Args: func(cmd *cobra.Command, args []string) error {
 		if len(args) > 1 {
 			cmd.SilenceUsage = false

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -173,6 +173,8 @@ git drs fetch production
 
 Push local DRS objects to server. Uploads new files and registers metadata.
 
+**Deprecated:** Use `git push` (with the installed pre-push hook) for uploads and `git drs fetch` for cross-remote metadata promotion. `git drs push` will be removed in a future release.
+
 **Usage:**
 
 ```bash

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -120,7 +120,6 @@ git drs remote list
 git drs remote set staging
 
 # Or use specific remote for one command
-git drs push production
 git drs fetch staging
 ```
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -289,7 +289,6 @@ git drs remote list
 git drs remote set production
 
 # Option 2: Specify remote for single command
-git drs push staging
 git drs fetch production
 ```
 


### PR DESCRIPTION
Title: Deprecate git drs push command and update docs

Background:

What is cmd/push/main.go used for?
cmd/push/main.go implements the git drs push command, which manually uploads local DRS/LFS objects to a configured DRS server by invoking drsmap.PushLocalDrsObjects after resolving the remote from the config. This is a bespoke push path and not part of the Git LFS custom transfer protocol, which is handled elsewhere (e.g., git lfs/custom transfer flows). The implementation is purely CLI-driven and not tied to the LFS transfer protocol hooks.

Since this command is not part of the LFS custom transfer protocol, it will be deprecated

Summary

Mark git drs push as deprecated in the CLI, directing users to git push with the pre-push hook and git drs fetch for cross-remote promotion.

Document the deprecation in the command reference and update README command table to flag it as deprecated.

Remove git drs push examples from getting-started and troubleshooting docs to avoid recommending the deprecated workflow.

