### PR TITLE
dont delete repo;force push instead

### DIFF
--- a/tests/monorepos/e2e-monorepo-remote.sh
+++ b/tests/monorepos/e2e-monorepo-remote.sh
@@ -504,7 +504,7 @@ validate_config() {
 configure_remote_auth() {
   MONO_REMOTE_URL_AUTH="$MONO_REMOTE_URL"
   if [[ -n "$TEST_GITHUB_TOKEN" && "$MONO_REMOTE_URL" =~ ^https://github.com/ ]]; then
-    MONO_REMOTE_URL_AUTH="${MONO_REMOTE_URL/https:\/\/github.com\//https:\/\/x-access-token:${TEST_GITHUB_TOKEN}@github.com/}"
+    MONO_REMOTE_URL_AUTH="${MONO_REMOTE_URL/https:\/\/github.com\//https://x-access-token:${TEST_GITHUB_TOKEN}@github.com/}"
   fi
 }
 
@@ -571,11 +571,12 @@ delete_github_repo_if_requested() {
 
   require_cmd gh
   if GH_TOKEN="$TEST_GITHUB_TOKEN" gh api "/repos/${GITHUB_OWNER_REPO}" >/dev/null 2>&1; then
-    log "Deleting existing GitHub repo ${GITHUB_OWNER_REPO} for clean test run"
-    GH_TOKEN="$TEST_GITHUB_TOKEN" gh api -X DELETE "/repos/${GITHUB_OWNER_REPO}" >/dev/null
-    DELETED_REMOTE_REPO_AT_START=true
-    # Small wait to avoid eventual-consistency race with immediate recreation.
-    sleep 2
+    # log "Deleting existing GitHub repo ${GITHUB_OWNER_REPO} for clean test run"
+    # GH_TOKEN="$TEST_GITHUB_TOKEN" gh api -X DELETE "/repos/${GITHUB_OWNER_REPO}" >/dev/null
+    # DELETED_REMOTE_REPO_AT_START=true
+    # # Small wait to avoid eventual-consistency race with immediate recreation.
+    # sleep 2
+    log "Skipping deletion of existing GitHub repo ${GITHUB_OWNER_REPO}; using push -f instead"
   fi
 }
 
@@ -683,7 +684,7 @@ push_dataset() {
   git add .gitattributes
   git commit -m "Initialize LFS tracking" || true
   # Ensure origin/main is established as upstream for subsequent git-drs pushes.
-  git push --set-upstream "$MONO_REMOTE_NAME" "$MONO_GIT_BRANCH"
+  git push -f --set-upstream "$MONO_REMOTE_NAME" "$MONO_GIT_BRANCH"
 
   if [[ "$MONO_RUN_MULTIPART_SMOKE" == "true" ]]; then
     mkdir -p fixtures/multipart-smoke


### PR DESCRIPTION
## Monorepo E2E: avoid GitHub repo deletion, rely on force-push bootstrap

### Context
The monorepo remote E2E runner currently deletes the target GitHub repo at start (`MONO_DELETE_REMOTE_AT_START=true`) to guarantee a clean remote. In practice, this can cause instability (rate limits, eventual consistency, and recreate delays).  
This PR changes the cleanup/bootstrap strategy to keep existing repos and force-update the branch during initial push.

### Branch scope
- **Branch:** `fix/tests-monorepos`
- **Commits vs `main`:** `b437e88`
- **Files changed:** `tests/monorepos/e2e-monorepo-remote.sh` (1 file, 8 insertions / 7 deletions)

### What changed

#### 1) Stop deleting existing GitHub repo at test start
File: `tests/monorepos/e2e-monorepo-remote.sh`

- In `delete_github_repo_if_requested()`, the existing delete flow is disabled:
  - `gh api -X DELETE /repos/...` call is commented out
  - `DELETED_REMOTE_REPO_AT_START=true` and sleep are no longer executed
- Added explicit log message:
  - `Skipping deletion of existing GitHub repo ...; using push -f instead`

**Why:** reduces test flakiness due to repo deletion/recreation timing and API-side consistency behavior.

#### 2) Force-update initial branch push
File: `tests/monorepos/e2e-monorepo-remote.sh`

- In `push_dataset()`, changed initial upstream push from:
  - `git push --set-upstream ...`
  - to `git push -f --set-upstream ...`

**Why:** ensures bootstrap succeeds even when remote branch already exists from previous runs.

#### 3) Minor auth URL formatting normalization
File: `tests/monorepos/e2e-monorepo-remote.sh`

- In `configure_remote_auth()`, normalized GitHub token URL substitution string formatting.
- Functional behavior remains equivalent.

### Behavioral impact
- Existing remote test repos are now retained instead of being deleted each run.
- Initial push can overwrite existing remote branch history due to `-f`.
- Test setup is expected to be more reliable for repeated runs against the same remote repo.

### Risks / trade-offs
- `git push -f` rewrites remote branch history for the test branch.
- Reusing an existing repo can preserve non-branch state (e.g., tags/settings) unless separately cleaned.
- If users point the runner at a shared/non-disposable repository, forced updates may be undesirable.

### Validation
- Verified branch diff against `origin/main`:
  - `git diff --name-status origin/main...HEAD`
  - `git diff origin/main...HEAD -- tests/monorepos/e2e-monorepo-remote.sh`
- Confirmed all branch changes are limited to the monorepo E2E script.

### Checklist
- [x] Scope limited to test runner script
- [x] No production command-path code changed
- [x] No dependency or config schema changes
- [x] Logging updated to reflect new behavior