### PR TITLE
fix/releaser

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -52,5 +52,3 @@ archives:
   - formats:
       - tar.gz
     name_template: "{{.ProjectName}}-{{.Os}}-{{.Arch}}-v{{.Version}}"
-    files:
-      - none: "*"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -52,4 +52,8 @@ archives:
   - formats:
       - tar.gz
     name_template: "{{.ProjectName}}-{{.Os}}-{{.Arch}}-v{{.Version}}"
-    files: []
+
+    # HACK: Provide a file glob that matches nothing in your directory.
+    # This prevents GoReleaser from reverting to default README/LICENSE fallback files.
+    files:
+      - none*

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -52,6 +52,4 @@ archives:
   - formats:
       - tar.gz
     name_template: "{{.ProjectName}}-{{.Os}}-{{.Arch}}-v{{.Version}}"
-    files:
-      - src: "{{.Path}}"
-        dst: .
+    files: []

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -52,4 +52,6 @@ archives:
   - formats:
       - tar.gz
     name_template: "{{.ProjectName}}-{{.Os}}-{{.Arch}}-v{{.Version}}"
-    files: []
+    files:
+      - src: "{{.Path}}"
+        dst: .

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -52,3 +52,4 @@ archives:
   - formats:
       - tar.gz
     name_template: "{{.ProjectName}}-{{.Os}}-{{.Arch}}-v{{.Version}}"
+    files: []


### PR DESCRIPTION
Ensure that the README.md file is not included in the tar.gz file

Why This Works

The GoReleaser Behavior: If files is completely empty or omitted, the internal fallback code logic triggers and searches your repository root for files like README.md or LICENSE.

The `none*` Workaround: 

Providing a list element like - none* convinces GoReleaser that you have manually overridden the file list. Because the glob pattern doesn't actually match any real files in your project, it resolves to zero extra assets. Your final .tar.gz package will contain exclusively the binary.

The official documentation for GoReleaser explicitly confirms that if the files property is left empty, the tool automatically fallbacks to injecting the root README and LICENSE documents.
The none* workaround is documented directly by the authors as the official strategy to bypass this packaging fallback mechanism.
You can find the official references and community tracking for this solution here:

* Check out the GoReleaser Archives Customization Guide to view the direct section explaining how any non-matching glob pattern forces the tool to package only the binary.
* You can also review the original community design discussion and implementation details outlined in GoReleaser GitHub Issue #602.

 https://goreleaser.com/customization/package/archives/#:~:text=Packaging%20only%20the%20binaries%20%23,will%20be%20added%20to%20the
 
