### PR TITLE
fix/sign-and-notarize

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -52,4 +52,8 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          APPLE_CERT_DATA: ${{ secrets.APPLE_CERT_DATA }}
+          APPLE_CERT_PASSWORD: ${{ secrets.APPLE_CERT_PASSWORD }}
+          APPLE_NOTARY_PASSWORD: ${{ secrets.APPLE_NOTARY_PASSWORD }}
+          APPLE_NOTARY_USER: ${{ secrets.APPLE_NOTARY_USER }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -13,14 +13,15 @@ builds:
       post:
         - codesign --force --options=runtime -s "{{ .Env.APPLE_TEAM_ID }}" "{{ .Path }}"
         - >-
-          sh -c 'ZIP_PATH="$(mktemp -t git-drs-notary-XXXXXX).zip";
+          sh -c 'set -e;
+          ZIP_PATH="$(mktemp -t git-drs-notary-XXXXXX).zip";
+          trap "rm -f \"$ZIP_PATH\"" EXIT;
           ditto -c -k --keepParent "{{ .Path }}" "$ZIP_PATH";
           xcrun notarytool submit "$ZIP_PATH"
           --apple-id "{{ .Env.APPLE_NOTARY_USER }}"
           --password "{{ .Env.APPLE_NOTARY_PASSWORD }}"
           --team-id "{{ .Env.APPLE_TEAM_ID }}"
-          --wait;
-          rm -f "$ZIP_PATH"'
+          --wait'
   - id: darwin-arm64
     binary: git-drs
     goos:
@@ -33,14 +34,15 @@ builds:
       post:
         - codesign --force --options=runtime -s "{{ .Env.APPLE_TEAM_ID }}" "{{ .Path }}"
         - >-
-          sh -c 'ZIP_PATH="$(mktemp -t git-drs-notary-XXXXXX).zip";
+          sh -c 'set -e;
+          ZIP_PATH="$(mktemp -t git-drs-notary-XXXXXX).zip";
+          trap "rm -f \"$ZIP_PATH\"" EXIT;
           ditto -c -k --keepParent "{{ .Path }}" "$ZIP_PATH";
           xcrun notarytool submit "$ZIP_PATH"
           --apple-id "{{ .Env.APPLE_NOTARY_USER }}"
           --password "{{ .Env.APPLE_NOTARY_PASSWORD }}"
           --team-id "{{ .Env.APPLE_TEAM_ID }}"
-          --wait;
-          rm -f "$ZIP_PATH"'
+          --wait'
   - id: linux-amd64
     binary: git-drs
     goos:
@@ -66,3 +68,12 @@ release:
 env_files:
   github_token: .github_token
 
+archives:
+  - formats:
+      - tar.gz
+    name_template: "{{.ProjectName}}-{{.Os}}-{{.Arch}}-v{{.Version}}"
+
+    # HACK: Provide a file glob that matches nothing in your directory.
+    # This prevents GoReleaser from reverting to default README/LICENSE fallback files.
+    files:
+      - none*

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -12,6 +12,16 @@ builds:
     hooks:
       post:
         - codesign --force --options=runtime -s "{{ .Env.APPLE_TEAM_ID }}" "{{ .Path }}"
+        - >-
+          sh -c 'ZIP_PATH="$(mktemp -t git-drs-notary-XXXXXX).zip";
+          ditto -c -k --keepParent "{{ .Path }}" "$ZIP_PATH";
+          xcrun notarytool submit "$ZIP_PATH"
+          --apple-id "{{ .Env.APPLE_NOTARY_USER }}"
+          --password "{{ .Env.APPLE_NOTARY_PASSWORD }}"
+          --team-id "{{ .Env.APPLE_TEAM_ID }}"
+          --wait;
+          rm -f "$ZIP_PATH"'
+        - xcrun stapler staple "{{ .Path }}"
   - id: darwin-arm64
     binary: git-drs
     goos:
@@ -23,6 +33,16 @@ builds:
     hooks:
       post:
         - codesign --force --options=runtime -s "{{ .Env.APPLE_TEAM_ID }}" "{{ .Path }}"
+        - >-
+          sh -c 'ZIP_PATH="$(mktemp -t git-drs-notary-XXXXXX).zip";
+          ditto -c -k --keepParent "{{ .Path }}" "$ZIP_PATH";
+          xcrun notarytool submit "$ZIP_PATH"
+          --apple-id "{{ .Env.APPLE_NOTARY_USER }}"
+          --password "{{ .Env.APPLE_NOTARY_PASSWORD }}"
+          --team-id "{{ .Env.APPLE_TEAM_ID }}"
+          --wait;
+          rm -f "$ZIP_PATH"'
+        - xcrun stapler staple "{{ .Path }}"
   - id: linux-amd64
     binary: git-drs
     goos:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -21,7 +21,6 @@ builds:
           --team-id "{{ .Env.APPLE_TEAM_ID }}"
           --wait;
           rm -f "$ZIP_PATH"'
-        - xcrun stapler staple "{{ .Path }}"
   - id: darwin-arm64
     binary: git-drs
     goos:
@@ -42,7 +41,6 @@ builds:
           --team-id "{{ .Env.APPLE_TEAM_ID }}"
           --wait;
           rm -f "$ZIP_PATH"'
-        - xcrun stapler staple "{{ .Path }}"
   - id: linux-amd64
     binary: git-drs
     goos:
@@ -68,12 +66,3 @@ release:
 env_files:
   github_token: .github_token
 
-archives:
-  - formats:
-      - tar.gz
-    name_template: "{{.ProjectName}}-{{.Os}}-{{.Arch}}-v{{.Version}}"
-
-    # HACK: Provide a file glob that matches nothing in your directory.
-    # This prevents GoReleaser from reverting to default README/LICENSE fallback files.
-    files:
-      - none*


### PR DESCRIPTION
## Summary

This PR adds macOS signing and notarization to the release pipeline for the `darwin-amd64` and `darwin-arm64` GoReleaser builds.

The Darwin build hooks now:

- Sign each macOS binary with `codesign --force --options=runtime`.
- Package the signed binary into a temporary zip using `ditto`.
- Submit the zip to Apple notarization with `xcrun notarytool submit`.
- Wait for notarization to complete before continuing the release.
- Remove the temporary notarization zip after submission completes.

The GitHub Actions release workflow also exposes the Apple credential secrets required by the GoReleaser hooks.

## Motivation

macOS users can encounter Gatekeeper warnings when downloading and running unsigned or unnotarized binaries. Signing and notarizing the macOS release artifacts during the release workflow improves trust and compatibility for distributed binaries.

This change automates that process as part of the existing GoReleaser release job.

## Changes

- Added post-build hooks for the `darwin-amd64` GoReleaser build to:
  - sign the binary,
  - create a temporary notarization zip,
  - submit it to Apple Notary,
  - wait for notarization,
  - and clean up the temporary zip.

- Added the same post-build signing and notarization hooks for the `darwin-arm64` build.

- Updated the GitHub Actions release workflow to pass the following Apple secrets into the GoReleaser step:
  - `APPLE_CERT_DATA`
  - `APPLE_CERT_PASSWORD`
  - `APPLE_NOTARY_PASSWORD`
  - `APPLE_NOTARY_USER`
  - `APPLE_TEAM_ID`

- Kept the existing Apple Developer certificate import step so `codesign` can access the signing identity from the temporary keychain.

## Notes

This PR intentionally does not run `xcrun stapler staple` on the raw CLI binary. A previous release attempt failed with stapler `Error 73` when stapling the built executable directly. The updated flow keeps notarization submission and removes the stapling step that caused the release failure.

## Testing

- Validated `.goreleaser.yaml` and `.github/workflows/release.yaml` as YAML.
- Verified there are no whitespace errors with `git diff --check`.

The full notarization flow must be exercised by the macOS GitHub Actions release runner because it depends on Apple credentials, the imported signing certificate, `codesign`, `ditto`, and `xcrun notarytool`.